### PR TITLE
Fix categorical legend colors to match spot fill scheme

### DIFF
--- a/src/lib/components/colorbar.svelte
+++ b/src/lib/components/colorbar.svelte
@@ -38,7 +38,8 @@
       if (ks) {
         elem = Plot.legend({
           color: {
-            domain: ks.map((x) => `${x}`.toString()) // Convert null to string
+            domain: ks.map((x) => `${x}`.toString()), // Convert null to string
+            scheme: 'tableau10' // LAG: fixes two-palette divergence in the browser code
           },
           legend: 'swatches',
           className: 'alphabet',


### PR DESCRIPTION
Closes #132.

## Problem
For categorical features, the legend swatches and the spot fills are drawn from two different color palettes, so every swatch color disagrees with the spots it labels.

- Spots are filled from `d3.schemeTableau10` in `src/lib/ui/overlays/featureColormap.ts` (`genCategoricalColors`, indexed by `value % 10`).
- The legend in `src/lib/components/colorbar.svelte` calls `Plot.legend({ color: { domain } })` with no `scheme`. For an implicit ordinal color scale, Observable Plot defaults to `observable10`, not `tableau10` (`src/scales/ordinal.js`: `scheme = type === "ordinal" ? "turbo" : "observable10"`).

The two schemes share no colors, e.g. category index 0 is `#4e79a7` on the spots but `#4269d0` in the legend, index 5 is `#edc949` vs `#ff8ab7`. The domain ordering is correct on both sides, so legend entries sit in the right positions; only the hues are wrong. This should affect every categorical feature.

## Fix
Pin the legend's color scale to the same scheme the spots use (`tableau10`).

## Verification
Load a sample with a categorical feature and confirm each legend swatch now matches its spots (e.g. both `#4e79a7` for the first category).

## Known limitation
Features with more than 10 categories will likely still diverge: the spot style wraps with `% 10`, while Plot's ordinal scale recycles a 10-color scheme differently past 10 entries. This PR aligns the two for the common case (≤10 categories); a fully consistent >10 mapping would need the legend to apply the same modulo, which is out of scope here.