### PR TITLE
Track viewer state (center, zoom, feature) in the URL

### DIFF
--- a/e2e/urlState.spec.ts
+++ b/e2e/urlState.spec.ts
@@ -1,16 +1,18 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 // A single sample keeps the network load light for these viewport-focused tests.
 const DATA_BASE = process.env.URLSTATE_DATA_BASE ?? 'data.samuibrowser.com/VisiumIF/';
 const SAMPLE = process.env.URLSTATE_SAMPLE ?? 'Br2720_Ant_IF';
+const SECOND_SAMPLE = process.env.URLSTATE_SECOND_SAMPLE ?? 'Br6432_Ant_IF';
 const LOAD_URL = `/from?url=${DATA_BASE}&s=${SAMPLE}`;
+const MULTI_LOAD_URL = `/from?url=${DATA_BASE}&s=${SAMPLE}&s=${SECOND_SAMPLE}`;
 
 // Remote sample loading over the network can be slow; give it room.
 test.describe.configure({ timeout: 90000 });
 
 // Wait until the map exists and its view has been fit (a center is set). Avoids
 // the `renderComplete` edge-trigger, whose transient value the poller can miss.
-async function gotoSamui(page: import('@playwright/test').Page, url: string) {
+async function gotoSamui(page: Page, url: string) {
   await page.goto(url, { waitUntil: 'domcontentloaded' });
   await page.waitForFunction(
     () => !!(window as any).__SAMUI__?.stores?.sMapp?.()?.map?.getView?.()?.getCenter?.(),
@@ -19,8 +21,19 @@ async function gotoSamui(page: import('@playwright/test').Page, url: string) {
   );
 }
 
+async function importantFeature(page: Page, sample: string) {
+  const manifest = await page.request.get(`https://${DATA_BASE}${sample}/sample.json`);
+  expect(manifest.ok(), `${sample}/sample.json reachable`).toBeTruthy();
+  const important = ((await manifest.json()).overlayParams?.importantFeatures ?? []) as {
+    group: string;
+    feature: string;
+  }[];
+  expect(important.length, `${sample} has an important feature to restore`).toBeGreaterThan(0);
+  return important[0];
+}
+
 // Same pixel<->meter convention as src/lib/ui/urlState.ts (y axis negated).
-async function readView(page: import('@playwright/test').Page) {
+async function readView(page: Page) {
   return page.evaluate(() => {
     const stores = (window as any).__SAMUI__.stores;
     const mapp = stores.sMapp();
@@ -37,17 +50,40 @@ async function readView(page: import('@playwright/test').Page) {
   });
 }
 
+async function waitForRestoredView(
+  page: Page,
+  target: { sample?: string; x: number; y: number; z: number; group: string; feature: string }
+) {
+  await page.waitForFunction(
+    ({ sample, x, y, z, group, feature }) => {
+      if (sample) {
+        const sampleSelect = document.querySelector('[data-testid="sample-select"]');
+        if (!sampleSelect?.textContent?.includes(sample)) return false;
+      }
+
+      const stores = (window as any).__SAMUI__.stores;
+      const mapp = stores.sMapp?.();
+      const view = mapp?.map?.getView?.();
+      if (!view || mapp.mPerPx == null) return false;
+      const c = view.getCenter();
+      if (!c) return false;
+      const cf = stores.overlays()[stores.sOverlay()]?.currFeature;
+      return (
+        Math.abs(c[0] / mapp.mPerPx - x) <= 1 &&
+        Math.abs(-c[1] / mapp.mPerPx - y) <= 1 &&
+        Math.abs((view.getZoom() ?? 0) - z) <= 0.02 &&
+        cf?.group === group &&
+        cf?.feature === feature
+      );
+    },
+    target,
+    { timeout: 30000 }
+  );
+}
+
 test.describe('URL viewer-state sync', () => {
   test('restores center, zoom, and feature from the query string', async ({ page }) => {
-    // Pull a real feature from the sample manifest without loading the whole app.
-    const manifest = await page.request.get(`https://${DATA_BASE}${SAMPLE}/sample.json`);
-    expect(manifest.ok(), 'sample.json reachable').toBeTruthy();
-    const important = ((await manifest.json()).overlayParams?.importantFeatures ?? []) as {
-      group: string;
-      feature: string;
-    }[];
-    expect(important.length, 'an important feature to restore').toBeGreaterThan(0);
-    const { group, feature } = important[0];
+    const { group, feature } = await importantFeature(page, SAMPLE);
 
     const targetX = 6000;
     const targetY = 6000;
@@ -59,32 +95,52 @@ test.describe('URL viewer-state sync', () => {
     await gotoSamui(page, restoreUrl);
 
     // Restore lands after renderComplete and the feature reload; poll until settled.
-    await page.waitForFunction(
-      ({ x, y, z, g, f }) => {
-        const stores = (window as any).__SAMUI__.stores;
-        const mapp = stores.sMapp?.();
-        const view = mapp?.map?.getView?.();
-        if (!view || mapp.mPerPx == null) return false;
-        const c = view.getCenter();
-        if (!c) return false;
-        const cf = stores.overlays()[stores.sOverlay()]?.currFeature;
-        return (
-          Math.abs(c[0] / mapp.mPerPx - x) <= 1 &&
-          Math.abs(-c[1] / mapp.mPerPx - y) <= 1 &&
-          Math.abs((view.getZoom() ?? 0) - z) <= 0.02 &&
-          cf?.group === g &&
-          cf?.feature === f
-        );
-      },
-      { x: targetX, y: targetY, z: targetZoom, g: group, f: feature },
-      { timeout: 30000 }
-    );
+    await waitForRestoredView(page, {
+      x: targetX,
+      y: targetY,
+      z: targetZoom,
+      group,
+      feature
+    });
 
     const view = await readView(page);
     expect(Math.round(view.pixelX)).toBe(targetX);
     expect(Math.round(view.pixelY)).toBe(targetY);
     expect(view.zoom).toBeCloseTo(targetZoom, 1);
     expect(view.feature).toEqual({ group, feature });
+  });
+
+  test('restores the requested sample from a multi-sample shared URL before writing state', async ({
+    page
+  }) => {
+    const { group, feature } = await importantFeature(page, SECOND_SAMPLE);
+
+    const targetX = 6000;
+    const targetY = 6000;
+    const targetZoom = 4.2;
+    const restoreUrl =
+      `${MULTI_LOAD_URL}&sample=${encodeURIComponent(SECOND_SAMPLE)}` +
+      `&x=${targetX}&y=${targetY}&z=${targetZoom}` +
+      `&g=${encodeURIComponent(group)}&f=${encodeURIComponent(feature)}`;
+
+    await gotoSamui(page, restoreUrl);
+
+    await waitForRestoredView(page, {
+      sample: SECOND_SAMPLE,
+      x: targetX,
+      y: targetY,
+      z: targetZoom,
+      group,
+      feature
+    });
+
+    await expect(page.getByTestId('sample-select')).toContainText(SECOND_SAMPLE);
+    const params = new URLSearchParams(new URL(page.url()).search);
+    expect(params.get('url')).toBe(DATA_BASE);
+    expect(params.getAll('s')).toEqual([SAMPLE, SECOND_SAMPLE]);
+    expect(params.get('sample')).toBe(SECOND_SAMPLE);
+    expect(params.get('g')).toBe(group);
+    expect(params.get('f')).toBe(feature);
   });
 
   test('writes the displayed image channels to the query string and restores them', async ({
@@ -94,11 +150,9 @@ test.describe('URL viewer-state sync', () => {
 
     // The composite controller initialises after the image loads and writes its
     // enabled channels to `c` (debounced ~300ms). Preserve the load params.
-    await page.waitForFunction(
-      () => !!new URLSearchParams(window.location.search).get('c'),
-      null,
-      { timeout: 30000 }
-    );
+    await page.waitForFunction(() => !!new URLSearchParams(window.location.search).get('c'), null, {
+      timeout: 30000
+    });
     const defaults = new URLSearchParams(new URL(page.url()).search);
     expect(defaults.get('url')).toBeTruthy();
     expect(defaults.getAll('s')).toContain(SAMPLE);

--- a/e2e/urlState.spec.ts
+++ b/e2e/urlState.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from '@playwright/test';
+
+// A single sample keeps the network load light for these viewport-focused tests.
+const DATA_BASE = process.env.URLSTATE_DATA_BASE ?? 'data.samuibrowser.com/VisiumIF/';
+const SAMPLE = process.env.URLSTATE_SAMPLE ?? 'Br2720_Ant_IF';
+const LOAD_URL = `/from?url=${DATA_BASE}&s=${SAMPLE}`;
+
+// Remote sample loading over the network can be slow; give it room.
+test.describe.configure({ timeout: 90000 });
+
+// Wait until the map exists and its view has been fit (a center is set). Avoids
+// the `renderComplete` edge-trigger, whose transient value the poller can miss.
+async function gotoSamui(page: import('@playwright/test').Page, url: string) {
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    () => !!(window as any).__SAMUI__?.stores?.sMapp?.()?.map?.getView?.()?.getCenter?.(),
+    null,
+    { timeout: 60000 }
+  );
+}
+
+// Same pixel<->meter convention as src/lib/ui/urlState.ts (y axis negated).
+async function readView(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const stores = (window as any).__SAMUI__.stores;
+    const mapp = stores.sMapp();
+    const mPerPx = mapp.mPerPx as number;
+    const center = mapp.map.getView().getCenter() as [number, number];
+    return {
+      pixelX: center[0] / mPerPx,
+      pixelY: -center[1] / mPerPx,
+      zoom: mapp.map.getView().getZoom() as number,
+      feature: stores.overlays()[stores.sOverlay()]?.currFeature as
+        | { group: string; feature: string }
+        | undefined
+    };
+  });
+}
+
+test.describe('URL viewer-state sync', () => {
+  test('restores center, zoom, and feature from the query string', async ({ page }) => {
+    // Pull a real feature from the sample manifest without loading the whole app.
+    const manifest = await page.request.get(`https://${DATA_BASE}${SAMPLE}/sample.json`);
+    expect(manifest.ok(), 'sample.json reachable').toBeTruthy();
+    const important = ((await manifest.json()).overlayParams?.importantFeatures ?? []) as {
+      group: string;
+      feature: string;
+    }[];
+    expect(important.length, 'an important feature to restore').toBeGreaterThan(0);
+    const { group, feature } = important[0];
+
+    const targetX = 6000;
+    const targetY = 6000;
+    const targetZoom = 4.2;
+    const restoreUrl =
+      `${LOAD_URL}&x=${targetX}&y=${targetY}&z=${targetZoom}` +
+      `&g=${encodeURIComponent(group)}&f=${encodeURIComponent(feature)}`;
+
+    await gotoSamui(page, restoreUrl);
+
+    // Restore lands after renderComplete and the feature reload; poll until settled.
+    await page.waitForFunction(
+      ({ x, y, z, g, f }) => {
+        const stores = (window as any).__SAMUI__.stores;
+        const mapp = stores.sMapp?.();
+        const view = mapp?.map?.getView?.();
+        if (!view || mapp.mPerPx == null) return false;
+        const c = view.getCenter();
+        if (!c) return false;
+        const cf = stores.overlays()[stores.sOverlay()]?.currFeature;
+        return (
+          Math.abs(c[0] / mapp.mPerPx - x) <= 1 &&
+          Math.abs(-c[1] / mapp.mPerPx - y) <= 1 &&
+          Math.abs((view.getZoom() ?? 0) - z) <= 0.02 &&
+          cf?.group === g &&
+          cf?.feature === f
+        );
+      },
+      { x: targetX, y: targetY, z: targetZoom, g: group, f: feature },
+      { timeout: 30000 }
+    );
+
+    const view = await readView(page);
+    expect(Math.round(view.pixelX)).toBe(targetX);
+    expect(Math.round(view.pixelY)).toBe(targetY);
+    expect(view.zoom).toBeCloseTo(targetZoom, 1);
+    expect(view.feature).toEqual({ group, feature });
+  });
+
+  test('writes center and zoom to the query string on map move, preserving load params', async ({
+    page
+  }) => {
+    await gotoSamui(page, LOAD_URL);
+
+    // Drive a real moveend (programmatic setCenter/setZoom does not emit one).
+    await page.evaluate(() => {
+      const mapp = (window as any).__SAMUI__.stores.sMapp();
+      const m = mapp.mPerPx as number;
+      mapp.map.getView().animate({ center: [3000 * m, -3000 * m], zoom: 5, duration: 1 });
+    });
+
+    // Writes are debounced (~300ms) via history.replaceState.
+    await page.waitForFunction(
+      () => {
+        const p = new URLSearchParams(window.location.search);
+        return p.get('x') === '3000' && p.get('y') === '3000' && p.get('z') === '5';
+      },
+      null,
+      { timeout: 10000 }
+    );
+
+    // The sample-loading params survive the rewrite.
+    const params = new URLSearchParams(new URL(page.url()).search);
+    expect(params.get('url')).toBeTruthy();
+    expect(params.getAll('s')).toContain(SAMPLE);
+  });
+});

--- a/e2e/urlState.spec.ts
+++ b/e2e/urlState.spec.ts
@@ -87,6 +87,46 @@ test.describe('URL viewer-state sync', () => {
     expect(view.feature).toEqual({ group, feature });
   });
 
+  test('writes the displayed image channels to the query string and restores them', async ({
+    page
+  }) => {
+    await gotoSamui(page, LOAD_URL);
+
+    // The composite controller initialises after the image loads and writes its
+    // enabled channels to `c` (debounced ~300ms). Preserve the load params.
+    await page.waitForFunction(
+      () => !!new URLSearchParams(window.location.search).get('c'),
+      null,
+      { timeout: 30000 }
+    );
+    const defaults = new URLSearchParams(new URL(page.url()).search);
+    expect(defaults.get('url')).toBeTruthy();
+    expect(defaults.getAll('s')).toContain(SAMPLE);
+
+    // Take one of the displayed channels and pin it to a single color, then reload.
+    const firstChannel = defaults.get('c')!.split(',')[0].split(':')[0];
+    const restoreUrl = `${LOAD_URL}&c=${encodeURIComponent(`${firstChannel}:white`)}`;
+    await gotoSamui(page, restoreUrl);
+
+    // The restored selection flows into the controller, which persists to localStorage
+    // on every style update — assert exactly that one channel is enabled, in white.
+    await page.waitForFunction(
+      (channel) => {
+        const raw = localStorage.getItem('imgCtrl');
+        if (!raw) return false;
+        const ctrl = JSON.parse(raw);
+        if (ctrl?.type !== 'composite') return false;
+        const target = ctrl.variables[channel];
+        if (!target?.enabled || target.color !== 'white') return false;
+        return Object.entries(ctrl.variables).every(
+          ([name, info]) => name === channel || !(info as { enabled: boolean }).enabled
+        );
+      },
+      firstChannel,
+      { timeout: 30000 }
+    );
+  });
+
   test('writes center and zoom to the query string on map move, preserving load params', async ({
     page
   }) => {

--- a/src/lib/ui/background/imgColormap.ts
+++ b/src/lib/ui/background/imgColormap.ts
@@ -21,6 +21,9 @@ export type CompCtrl = { type: 'composite'; variables: Record<string, BandInfo> 
 export type RGBCtrl = { type: 'rgb'; Exposure: number; Contrast: number; Saturation: number };
 export type ImgCtrl = CompCtrl | RGBCtrl;
 
+/** An enabled channel and the RGB slot it is mapped to (see {@link maskMap}). */
+export type ChannelSelection = { channel: string; color: (typeof colors)[number] };
+
 export function genCompStyle(
   bands: string[],
   max: number,

--- a/src/lib/ui/background/imgControl.browser.test.ts
+++ b/src/lib/ui/background/imgControl.browser.test.ts
@@ -1,5 +1,6 @@
-import { sEvent } from '$lib/store';
+import { sEvent, sSample } from '$lib/store';
 import { ImgData, type ImageParams } from '$src/lib/data/objects/image';
+import { Sample } from '$src/lib/data/objects/sample';
 import { Background } from '$src/lib/ui/background/imgBackground';
 import type { BandInfo, CompCtrl, ImgCtrl, RGBCtrl } from '$src/lib/ui/background/imgColormap';
 import ImgControl from '$src/lib/ui/background/imgControl.svelte';
@@ -79,6 +80,10 @@ function getChannelRow(screen: ImgControlScreen, name: string): HTMLTableRowElem
 
 beforeEach(() => {
   localStorage.clear();
+  // imgControl now syncs channels to the query string; reset it so a `c`/`sample`
+  // written by one test cannot leak into the next.
+  history.replaceState(null, '', window.location.pathname);
+  sSample.set(undefined);
 });
 
 async function setupCompositeControl(overrides?: Partial<ImageParams>) {
@@ -251,6 +256,48 @@ test('prevents duplicate colors across enabled channels', async () => {
   expect(state.variables.actin.enabled).toBe(false);
 
   screen.unmount();
+});
+
+test('holds channel URL writes until the requested sample is the active one', async () => {
+  // A multi-sample shared URL requests sample B with a channel only B has, while
+  // the mounted control still shows the transient first sample A. Without gating,
+  // A's control would write its own defaults to `c`, clobbering the shared `GFP:white`
+  // before B loads. (Same-channel samples never expose this; A must lack the channel.)
+  const shared = '?url=x&s=A&s=B&sample=B&c=' + encodeURIComponent('GFP:white');
+  history.replaceState(null, '', shared);
+  sSample.set(new Sample({ name: 'A' }));
+
+  const image = new ImgData({
+    urls: [{ url: '/tiles', type: 'network' }],
+    channels: ['dapi', 'actin', 'tubulin'],
+    mPerPx: 1,
+    maxVal: 4095,
+    defaultChannels: createDefaultChannels({ red: 'actin', green: 'tubulin', blue: 'dapi' })
+  });
+  const background = new BackgroundSpy(image);
+  const screen = render(ImgControl, { props: { background } });
+
+  sEvent.set({ type: 'sampleUpdated' });
+  await expect.poll(() => background.calls.length).toBeGreaterThan(0);
+
+  try {
+    // Past the 300ms write debounce, the shared selection is untouched: B is not active.
+    await wait(400);
+    expect(new URLSearchParams(window.location.search).get('c')).toBe('GFP:white');
+
+    // Once the requested sample becomes active, the gate latches open and writes resume.
+    // Use a distinct event type so the sampleEvent derived changes and rebuilds the controller.
+    sSample.set(new Sample({ name: 'B' }));
+    sEvent.set({ type: 'imgDefaultsUpdated' });
+    await expect
+      .poll(() => new URLSearchParams(window.location.search).get('c'), { timeout: 2000 })
+      .not.toBe('GFP:white');
+    expect(new URLSearchParams(window.location.search).get('c')).toContain('dapi:blue');
+  } finally {
+    screen.unmount();
+    sSample.set(undefined);
+    history.replaceState(null, '', '/');
+  }
 });
 
 test('handles range slider min/max constraints and sqrt transformation', async () => {

--- a/src/lib/ui/background/imgControl.svelte
+++ b/src/lib/ui/background/imgControl.svelte
@@ -4,16 +4,21 @@
   import type { ImgData } from '$src/lib/data/objects/image';
   import {
     type BandInfo,
+    type ChannelSelection,
     type CompCtrl,
     type ImgCtrl,
     type RGBCtrl
   } from '$src/lib/ui/background/imgColormap';
   import {
+    applyChannelSelections,
     buildCompositeController,
     buildRgbController,
     cloneController,
+    enabledChannels,
     selectChannelColor
   } from '$src/lib/ui/background/imgControlState';
+  import { parseChannels, writeChannelsToUrl } from '$src/lib/ui/urlState';
+  import { debounce } from 'lodash-es';
   import { Tooltip } from 'bits-ui';
   import { onMount } from 'svelte';
   import { fly } from 'svelte/transition';
@@ -40,6 +45,7 @@
   let rgbController = $state<RGBCtrl | undefined>(undefined);
 
   let mounted = false;
+  let channelsReady = false;
   let mountTimestamp = 0;
   let collapseTimer: ReturnType<typeof setTimeout> | null = null;
   let collapseInitiated = $state(false);
@@ -64,10 +70,14 @@
       controller = buildRgbController();
     } else if (Array.isArray(nextImage.channels)) {
       controller = buildCompositeController(nextImage);
+      if (typeof window !== 'undefined') {
+        applyChannelSelections(controller, parseChannels(window.location.search));
+      }
     } else {
       throw new Error('Invalid channel configuration');
     }
 
+    channelsReady = true;
     collapseInitiated = false;
   }
 
@@ -160,6 +170,14 @@
     background?.updateStyle(controllerSnapshot);
   });
 
+  const writeChannels = debounce((sel: ChannelSelection[]) => writeChannelsToUrl(sel), 300);
+
+  $effect(() => {
+    const snap = controllerSnapshot;
+    if (!channelsReady || snap?.type !== 'composite') return;
+    writeChannels(enabledChannels(snap));
+  });
+
   $effect(() => {
     const ctrl = controller;
     if (!mounted || !ctrl || collapseInitiated || !expanded || isHoveringControl()) return;
@@ -174,6 +192,7 @@
 
     return () => {
       clearCollapseTimer();
+      writeChannels.cancel();
       mounted = false;
       collapseInitiated = false;
     };

--- a/src/lib/ui/background/imgControl.svelte
+++ b/src/lib/ui/background/imgControl.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { sEvent } from '$lib/store';
+  import { sEvent, sSample } from '$lib/store';
   import GlassIsland from '$src/lib/components/glass/GlassIsland.svelte';
   import type { ImgData } from '$src/lib/data/objects/image';
   import {
@@ -17,10 +17,11 @@
     enabledChannels,
     selectChannelColor
   } from '$src/lib/ui/background/imgControlState';
-  import { parseChannels, writeChannelsToUrl } from '$src/lib/ui/urlState';
+  import { parseChannels, parseViewState, writeChannelsToUrl } from '$src/lib/ui/urlState';
   import { debounce } from 'lodash-es';
   import { Tooltip } from 'bits-ui';
   import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
   import { fly } from 'svelte/transition';
   import CompositeChannelTable from './CompositeChannelTable.svelte';
   import type { Background } from './imgBackground';
@@ -46,6 +47,14 @@
 
   let mounted = false;
   let channelsReady = false;
+  // The sample requested by the shared URL (if any). Captured at init, not in onMount:
+  // a sample event can trigger initialiseController (and the first write) before onMount
+  // runs, which would otherwise bypass the gate below.
+  const pendingSample =
+    typeof window !== 'undefined' ? parseViewState(window.location.search).sample : undefined;
+  // Latches once that sample is active; until then, channel writes are held so a
+  // transient earlier sample cannot clobber the shared `c` (mirrors UrlStateController).
+  let channelRestoreDone = false;
   let mountTimestamp = 0;
   let collapseTimer: ReturnType<typeof setTimeout> | null = null;
   let collapseInitiated = $state(false);
@@ -69,10 +78,13 @@
     if (nextImage.channels === 'rgb') {
       controller = buildRgbController();
     } else if (Array.isArray(nextImage.channels)) {
-      controller = buildCompositeController(nextImage);
+      // Apply the URL selection to the plain object, then assign once. Mutating the
+      // reactive `controller` proxy here instead would cascade into an effect loop.
+      const built = buildCompositeController(nextImage);
       if (typeof window !== 'undefined') {
-        applyChannelSelections(controller, parseChannels(window.location.search));
+        applyChannelSelections(built, parseChannels(window.location.search));
       }
+      controller = built;
     } else {
       throw new Error('Invalid channel configuration');
     }
@@ -175,6 +187,13 @@
   $effect(() => {
     const snap = controllerSnapshot;
     if (!channelsReady || snap?.type !== 'composite') return;
+    if (!channelRestoreDone) {
+      // Hold writes until the URL's requested sample is the one being shown. Read
+      // sSample non-reactively: the controller is rebuilt when a new sample's image
+      // loads, so this effect already re-runs (via controllerSnapshot) at that point.
+      if (pendingSample && get(sSample)?.name !== pendingSample) return;
+      channelRestoreDone = true;
+    }
     writeChannels(enabledChannels(snap));
   });
 
@@ -192,7 +211,8 @@
 
     return () => {
       clearCollapseTimer();
-      writeChannels.cancel();
+      // Persist the last pending selection rather than dropping it on teardown.
+      writeChannels.flush();
       mounted = false;
       collapseInitiated = false;
     };

--- a/src/lib/ui/background/imgControlState.test.ts
+++ b/src/lib/ui/background/imgControlState.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { ImgData } from '$src/lib/data/objects/image';
 import {
+  applyChannelSelections,
   buildCompositeController,
   buildRgbController,
   cloneController,
+  enabledChannels,
   restoreCompositeController,
   selectChannelColor
 } from './imgControlState';
@@ -96,5 +98,34 @@ describe('imgControlState helpers', () => {
 
     expect(restoreCompositeController(['a'])).toBeNull();
     spy.mockRestore();
+  });
+
+  it('enabledChannels lists the enabled channels and their colors', () => {
+    const ctrl = buildCompositeController(createCompositeImage());
+    expect(enabledChannels(ctrl)).toEqual([
+      { channel: 'dapi', color: 'red' },
+      { channel: 'actin', color: 'green' },
+      { channel: 'tubulin', color: 'blue' }
+    ]);
+    expect(enabledChannels(buildRgbController())).toEqual([]);
+  });
+
+  it('applyChannelSelections overrides the enabled set and colors', () => {
+    const ctrl = buildCompositeController(createCompositeImage());
+    applyChannelSelections(ctrl, [{ channel: 'actin', color: 'magenta' }]);
+
+    expect(ctrl.variables.actin).toMatchObject({ enabled: true, color: 'magenta' });
+    expect(ctrl.variables.dapi.enabled).toBe(false);
+    expect(ctrl.variables.tubulin.enabled).toBe(false);
+  });
+
+  it('applyChannelSelections leaves the controller untouched when nothing matches', () => {
+    const ctrl = buildCompositeController(createCompositeImage());
+    const before = cloneController(ctrl);
+
+    applyChannelSelections(ctrl, [{ channel: 'missing', color: 'red' }]);
+    applyChannelSelections(ctrl, []);
+
+    expect(ctrl).toEqual(before);
   });
 });

--- a/src/lib/ui/background/imgControlState.ts
+++ b/src/lib/ui/background/imgControlState.ts
@@ -2,6 +2,7 @@ import type { ImgData } from '$src/lib/data/objects/image';
 import {
   colors,
   type BandInfo,
+  type ChannelSelection,
   type CompCtrl,
   type ImgCtrl,
   type RGBCtrl
@@ -115,6 +116,36 @@ export function selectChannelColor(
 
   current.enabled = true;
   current.color = color;
+}
+
+/** The enabled channels of a composite controller, as {@link ChannelSelection}s for the URL. */
+export function enabledChannels(ctrl: ImgCtrl | undefined): ChannelSelection[] {
+  if (!ctrl || ctrl.type !== 'composite') return [];
+  return Object.entries(ctrl.variables)
+    .filter(([, info]) => info.enabled)
+    .map(([channel, info]) => ({ channel, color: info.color }));
+}
+
+/**
+ * Apply a URL-restored channel selection onto a freshly built composite controller,
+ * overriding the default/localStorage enabled set. Channels absent from the controller
+ * are ignored; if none match (e.g. a different image), the controller is left untouched
+ * rather than blanked.
+ */
+export function applyChannelSelections(
+  ctrl: ImgCtrl | undefined,
+  channels: ChannelSelection[]
+): void {
+  if (!ctrl || ctrl.type !== 'composite' || channels.length === 0) return;
+
+  const matches = channels.filter((c) => ctrl.variables[c.channel]);
+  if (matches.length === 0) return;
+
+  for (const info of Object.values(ctrl.variables)) info.enabled = false;
+  for (const { channel, color } of matches) {
+    ctrl.variables[channel].enabled = true;
+    ctrl.variables[channel].color = color;
+  }
 }
 
 export function cloneController(ctrl: ImgCtrl | undefined): ImgCtrl | undefined {

--- a/src/lib/ui/urlState.test.ts
+++ b/src/lib/ui/urlState.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildSearch, meterToPixel, parseViewState, pixelToMeter } from '$src/lib/ui/urlState';
+import {
+  buildSearch,
+  meterToPixel,
+  parseChannels,
+  parseViewState,
+  pixelToMeter,
+  setChannelParam
+} from '$src/lib/ui/urlState';
 
 describe('parseViewState', () => {
   it('parses a full state', () => {
@@ -89,6 +96,49 @@ describe('buildSearch', () => {
       sample: 'Br2720'
     };
     expect(parseViewState(buildSearch('', state))).toEqual(state);
+  });
+});
+
+describe('channel params', () => {
+  it('parses channel:color pairs', () => {
+    expect(parseChannels('?c=DAPI:blue,GFP:green')).toEqual([
+      { channel: 'DAPI', color: 'blue' },
+      { channel: 'GFP', color: 'green' }
+    ]);
+  });
+
+  it('returns an empty array when absent', () => {
+    expect(parseChannels('?x=1')).toEqual([]);
+    expect(parseChannels('')).toEqual([]);
+  });
+
+  it('drops segments with an unknown color or no channel name', () => {
+    expect(parseChannels('?c=DAPI:teal,GFP:green,:red,bad')).toEqual([
+      { channel: 'GFP', color: 'green' }
+    ]);
+  });
+
+  it('keeps colons in channel names (splits on the last one)', () => {
+    expect(parseChannels('?c=ratio:a:b:red')).toEqual([{ channel: 'ratio:a:b', color: 'red' }]);
+  });
+
+  it('sets the c param while preserving other params', () => {
+    const out = setChannelParam('?url=data.example.com/&x=1', [
+      { channel: 'DAPI', color: 'blue' }
+    ]);
+    const p = new URLSearchParams(out);
+    expect(p.get('url')).toBe('data.example.com/');
+    expect(p.get('x')).toBe('1');
+    expect(parseChannels(out)).toEqual([{ channel: 'DAPI', color: 'blue' }]);
+  });
+
+  it('removes the c param for an empty selection', () => {
+    expect(new URLSearchParams(setChannelParam('?c=DAPI:blue&x=1', [])).get('c')).toBeNull();
+  });
+
+  it('leaves c untouched through buildSearch (separate writers)', () => {
+    const out = buildSearch('?c=DAPI:blue', { zoom: 2 });
+    expect(new URLSearchParams(out).get('c')).toBe('DAPI:blue');
   });
 });
 

--- a/src/lib/ui/urlState.test.ts
+++ b/src/lib/ui/urlState.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSearch, meterToPixel, parseViewState, pixelToMeter } from '$src/lib/ui/urlState';
+
+describe('parseViewState', () => {
+  it('parses a full state', () => {
+    expect(parseViewState('?x=100&y=-50&z=3.5&g=genes&f=GFAP&sample=Br2720')).toEqual({
+      center: [100, -50],
+      zoom: 3.5,
+      feature: { group: 'genes', feature: 'GFAP' },
+      sample: 'Br2720'
+    });
+  });
+
+  it('requires both x and y for a center', () => {
+    expect(parseViewState('?x=100').center).toBeUndefined();
+    expect(parseViewState('?y=100').center).toBeUndefined();
+  });
+
+  it('requires both group and feature', () => {
+    expect(parseViewState('?g=genes').feature).toBeUndefined();
+    expect(parseViewState('?f=GFAP').feature).toBeUndefined();
+  });
+
+  it('ignores non-numeric and empty coordinates', () => {
+    expect(parseViewState('?x=foo&y=bar&z=baz')).toEqual({});
+    // Empty values must not coerce to 0.
+    expect(parseViewState('?x=&y=&z=')).toEqual({});
+  });
+
+  it('keeps zero coordinates and zoom', () => {
+    expect(parseViewState('?x=0&y=0&z=0')).toEqual({ center: [0, 0], zoom: 0 });
+  });
+
+  it('returns an empty state for an empty query', () => {
+    expect(parseViewState('')).toEqual({});
+  });
+});
+
+describe('buildSearch', () => {
+  it('preserves the existing sample-loading params', () => {
+    const out = buildSearch('?url=data.example.com/&s=Br2720', {
+      center: [10, 20],
+      zoom: 2,
+      feature: { group: 'genes', feature: 'GFAP' }
+    });
+    const p = new URLSearchParams(out);
+    expect(p.get('url')).toBe('data.example.com/');
+    expect(p.get('s')).toBe('Br2720');
+    expect(p.get('x')).toBe('10');
+    expect(p.get('y')).toBe('20');
+    expect(p.get('z')).toBe('2');
+    expect(p.get('g')).toBe('genes');
+    expect(p.get('f')).toBe('GFAP');
+  });
+
+  it('rounds center to integers and zoom to two decimals', () => {
+    const p = new URLSearchParams(buildSearch('', { center: [10.7, -20.2], zoom: 3.14159 }));
+    expect(p.get('x')).toBe('11');
+    expect(p.get('y')).toBe('-20');
+    expect(p.get('z')).toBe('3.14');
+  });
+
+  it('writes zero coordinates rather than dropping them', () => {
+    const p = new URLSearchParams(buildSearch('', { center: [0, 0], zoom: 0 }));
+    expect(p.get('x')).toBe('0');
+    expect(p.get('y')).toBe('0');
+    expect(p.get('z')).toBe('0');
+  });
+
+  it('removes only the viewer params, preserving url/s', () => {
+    const out = buildSearch('?url=data.example.com/&s=A&s=B&x=1&y=2&z=3&g=a&f=b&sample=c', {});
+    const p = new URLSearchParams(out);
+    expect(p.getAll('s')).toEqual(['A', 'B']);
+    expect(p.get('url')).toBe('data.example.com/');
+    expect(p.get('x')).toBeNull();
+    expect(p.get('g')).toBeNull();
+  });
+
+  it('rounds zoom lossily to two decimals (intentional)', () => {
+    expect(parseViewState(buildSearch('', { zoom: 3.14159 }))).toEqual({ zoom: 3.14 });
+  });
+
+  it('round-trips through parseViewState', () => {
+    const state = {
+      center: [10, -20] as [number, number],
+      zoom: 2.5,
+      feature: { group: 'genes', feature: 'GFAP' },
+      sample: 'Br2720'
+    };
+    expect(parseViewState(buildSearch('', state))).toEqual(state);
+  });
+});
+
+describe('pixel/meter conversion', () => {
+  it('negates the y axis and is invertible', () => {
+    expect(meterToPixel([100, 200], 2)).toEqual([50, -100]);
+    expect(pixelToMeter([50, -100], 2)).toEqual([100, 200]);
+    expect(pixelToMeter(meterToPixel([123, -456], 0.5), 0.5)).toEqual([123, -456]);
+  });
+});

--- a/src/lib/ui/urlState.test.ts
+++ b/src/lib/ui/urlState.test.ts
@@ -1,13 +1,46 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
 
+import { Sample } from '$src/lib/data/objects/sample';
+import { HoverSelect } from '$src/lib/sidebar/searchBox';
+import {
+  hoverSelect,
+  mapIdSample,
+  sEvent,
+  sMapId,
+  sMapp,
+  sOverlay,
+  sSample,
+  samples,
+  setHoverSelect
+} from '$src/lib/store';
+import type { Mapp } from '$src/lib/ui/mapp';
 import {
   buildSearch,
   meterToPixel,
   parseChannels,
   parseViewState,
   pixelToMeter,
-  setChannelParam
+  setChannelParam,
+  UrlStateController
 } from '$src/lib/ui/urlState';
+
+let resetFeatureId = 0;
+
+beforeEach(() => {
+  vi.useRealTimers();
+  sOverlay.set('active-overlay');
+  void setHoverSelect({
+    selected: { group: '__test_reset__', feature: String(resetFeatureId++) }
+  });
+  hoverSelect.set(new HoverSelect());
+  mapIdSample.set({});
+  samples.set([]);
+  sEvent.set(undefined);
+  sMapId.set(0);
+  sMapp.set(undefined);
+  sSample.set(undefined);
+});
 
 describe('parseViewState', () => {
   it('parses a full state', () => {
@@ -123,9 +156,7 @@ describe('channel params', () => {
   });
 
   it('sets the c param while preserving other params', () => {
-    const out = setChannelParam('?url=data.example.com/&x=1', [
-      { channel: 'DAPI', color: 'blue' }
-    ]);
+    const out = setChannelParam('?url=data.example.com/&x=1', [{ channel: 'DAPI', color: 'blue' }]);
     const p = new URLSearchParams(out);
     expect(p.get('url')).toBe('data.example.com/');
     expect(p.get('x')).toBe('1');
@@ -147,5 +178,84 @@ describe('pixel/meter conversion', () => {
     expect(meterToPixel([100, 200], 2)).toEqual([50, -100]);
     expect(pixelToMeter([50, -100], 2)).toEqual([100, 200]);
     expect(pixelToMeter(meterToPixel([123, -456], 0.5), 0.5)).toEqual([123, -456]);
+  });
+});
+
+describe('UrlStateController restore sequencing', () => {
+  it('waits for the requested sample before restoring the feature', () => {
+    const sampleA = new Sample({ name: 'A' });
+    const sampleB = new Sample({ name: 'B' });
+    const targetFeature = { group: 'genes', feature: 'GFAP' };
+
+    samples.set([
+      { name: 'A', sample: sampleA },
+      { name: 'B', sample: sampleB }
+    ]);
+    mapIdSample.set({ 0: 'A' });
+    sSample.set(sampleA);
+
+    const controller = new UrlStateController('?sample=B&g=genes&f=GFAP');
+    controller.start();
+
+    try {
+      sEvent.set({ type: 'sampleUpdated' });
+
+      expect(get(mapIdSample)[0]).toBe('B');
+      expect(get(hoverSelect).active).toBeUndefined();
+
+      sSample.set(sampleB);
+      sEvent.set({ type: 'sampleUpdated' });
+
+      expect(get(hoverSelect).active).toEqual(targetFeature);
+    } finally {
+      controller.stop();
+    }
+  });
+
+  it('does not write the current map state while the requested sample is still pending', () => {
+    vi.useFakeTimers();
+
+    const sampleA = new Sample({ name: 'A' });
+    const sampleB = new Sample({ name: 'B' });
+    const view = {
+      getCenter: () => [10, -20] as [number, number],
+      getZoom: () => 4,
+      setCenter: vi.fn(),
+      setZoom: vi.fn()
+    };
+    const fakeMapp = {
+      mPerPx: 1,
+      map: {
+        getView: () => view,
+        on: () => undefined
+      }
+    } as unknown as Mapp;
+
+    samples.set([
+      { name: 'A', sample: sampleA },
+      { name: 'B', sample: sampleB }
+    ]);
+    mapIdSample.set({ 0: 'A' });
+    sSample.set(sampleA);
+    sMapp.set(fakeMapp);
+    window.history.replaceState(null, '', '/?url=data.example.com&s=A&s=B&sample=B&g=genes&f=GFAP');
+
+    const controller = new UrlStateController(window.location.search);
+    controller.start();
+
+    try {
+      sEvent.set({ type: 'renderComplete' });
+      sEvent.set({ type: 'featureUpdated' });
+      vi.advanceTimersByTime(350);
+
+      const params = new URLSearchParams(window.location.search);
+      expect(params.get('x')).toBeNull();
+      expect(params.get('sample')).toBe('B');
+      expect(params.get('g')).toBe('genes');
+      expect(params.get('f')).toBe('GFAP');
+    } finally {
+      controller.stop();
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/lib/ui/urlState.ts
+++ b/src/lib/ui/urlState.ts
@@ -200,7 +200,6 @@ export class UrlStateController {
     if (get(sMapp)?.map?.getView()?.getCenter()) {
       this.attemptRestore();
       this.attachMoveEnd();
-      this.ready = true;
     }
   }
 
@@ -218,31 +217,36 @@ export class UrlStateController {
       this.attachMoveEnd();
     }
 
-    // The map has painted; further waiting is pointless. Open the write gate so
-    // user pans/zooms are recorded even if some state could not be restored.
-    if (type === 'renderComplete') this.ready = true;
-
     if (this.ready && (type === 'featureUpdated' || type === 'sampleUpdated')) this.write();
   }
 
   private attemptRestore() {
-    this.restoreSample();
-    this.restoreFeature();
-    this.restoreView();
+    const sampleReady = this.restoreSample();
+    if (sampleReady) {
+      this.restoreFeature();
+      this.restoreView();
+    }
     // Nothing left to restore -> begin tracking user changes immediately.
+    const needSample = !!this.pending.sample && !this.sampleRestored;
     const needFeature = !!this.pending.feature && !this.featureRestored;
     const needView =
       (!!this.pending.center || this.pending.zoom !== undefined) && !this.viewRestored;
-    if (!needFeature && !needView) this.ready = true;
+    if (!needSample && !needFeature && !needView) this.ready = true;
   }
 
-  private restoreSample() {
-    if (this.sampleRestored || !this.pending.sample) return;
-    this.sampleRestored = true;
-    if (get(sSample)?.name === this.pending.sample) return;
-    if (get(samples).some((s) => s.name === this.pending.sample)) {
-      mapIdSample.update((m) => ({ ...m, [get(sMapId)]: this.pending.sample! }));
+  private restoreSample(): boolean {
+    const sample = this.pending.sample;
+    if (this.sampleRestored || !sample) return true;
+
+    if (get(sSample)?.name === sample) {
+      this.sampleRestored = true;
+      return true;
     }
+
+    if (get(samples).some((s) => s.name === sample)) {
+      mapIdSample.update((m) => (m[get(sMapId)] === sample ? m : { ...m, [get(sMapId)]: sample }));
+    }
+    return false;
   }
 
   private restoreFeature() {

--- a/src/lib/ui/urlState.ts
+++ b/src/lib/ui/urlState.ts
@@ -3,6 +3,7 @@ import { unByKey } from 'ol/Observable.js';
 import type { EventsKey } from 'ol/events.js';
 import { get } from 'svelte/store';
 import type { FeatureAndGroup } from '../data/objects/feature';
+import { colors, type ChannelSelection } from './background/imgColormap';
 import {
   mapIdSample,
   mapTiles,
@@ -35,8 +36,11 @@ const PARAM = {
   z: 'z',
   group: 'g',
   feature: 'f',
-  sample: 'sample'
+  sample: 'sample',
+  channels: 'c'
 } as const;
+
+const COLOR_SET: ReadonlySet<string> = new Set(colors);
 
 // OpenLayers stores the center in projected meters. The app's pixel convention
 // (see sPixel in store.ts and changeHover in mapp.svelte) negates the y axis.
@@ -104,6 +108,48 @@ export function buildSearch(currentSearch: string, state: ViewState): string {
 
   const s = p.toString();
   return s ? `?${s}` : '';
+}
+
+/**
+ * Composite image channels ride in their own `c` param (e.g. `c=DAPI:blue,GFP:green`),
+ * separate from {@link ViewState}: the channel controller lives in component state
+ * (see imgControl.svelte), not the global stores {@link UrlStateController} syncs.
+ * Keeping `c` out of {@link buildSearch} also lets the two writers coexist without
+ * clobbering each other's params.
+ */
+export function parseChannels(search: string): ChannelSelection[] {
+  const raw = new URLSearchParams(search).get(PARAM.channels);
+  if (!raw) return [];
+
+  const out: ChannelSelection[] = [];
+  for (const seg of raw.split(',')) {
+    const i = seg.lastIndexOf(':');
+    if (i <= 0) continue; // No channel name, or no separator.
+    const channel = seg.slice(0, i);
+    const color = seg.slice(i + 1);
+    if (COLOR_SET.has(color)) out.push({ channel, color: color as ChannelSelection['color'] });
+  }
+  return out;
+}
+
+/** Merge the channel selection into {@link currentSearch}, preserving unrelated params. */
+export function setChannelParam(currentSearch: string, channels: ChannelSelection[]): string {
+  const p = new URLSearchParams(currentSearch);
+  setOrDelete(
+    p,
+    PARAM.channels,
+    channels.length ? channels.map((c) => `${c.channel}:${c.color}`).join(',') : undefined
+  );
+  const s = p.toString();
+  return s ? `?${s}` : '';
+}
+
+/** Persist the enabled channels to the URL. No-op outside single-map mode (see flush). */
+export function writeChannelsToUrl(channels: ChannelSelection[]): void {
+  if (typeof window === 'undefined' || !singleTile()) return;
+  const search = setChannelParam(window.location.search, channels);
+  const url = `${window.location.pathname}${search}${window.location.hash}`;
+  history.replaceState(history.state, '', url);
 }
 
 function effectiveMPerPx(map: Mapp): number | undefined {

--- a/src/lib/ui/urlState.ts
+++ b/src/lib/ui/urlState.ts
@@ -1,0 +1,266 @@
+import { debounce } from 'lodash-es';
+import { unByKey } from 'ol/Observable.js';
+import type { EventsKey } from 'ol/events.js';
+import { get } from 'svelte/store';
+import type { FeatureAndGroup } from '../data/objects/feature';
+import {
+  mapIdSample,
+  mapTiles,
+  overlays,
+  overlaysFeature,
+  samples,
+  sEvent,
+  sMapId,
+  sMapp,
+  sOverlay,
+  sSample,
+  setHoverSelect
+} from '../store';
+import type { Mapp } from './mapp';
+
+/** Viewer state that survives a page reload via the query string. */
+export type ViewState = {
+  /** Map center in image pixel coordinates (see {@link meterToPixel}). */
+  center?: [number, number];
+  zoom?: number;
+  /** Active overlay's feature ("selected layer"). */
+  feature?: FeatureAndGroup;
+  /** Active sample name. */
+  sample?: string;
+};
+
+const PARAM = {
+  x: 'x',
+  y: 'y',
+  z: 'z',
+  group: 'g',
+  feature: 'f',
+  sample: 'sample'
+} as const;
+
+// OpenLayers stores the center in projected meters. The app's pixel convention
+// (see sPixel in store.ts and changeHover in mapp.svelte) negates the y axis.
+export function meterToPixel(center: [number, number], mPerPx: number): [number, number] {
+  return [center[0] / mPerPx, -center[1] / mPerPx];
+}
+
+export function pixelToMeter(px: [number, number], mPerPx: number): [number, number] {
+  return [px[0] * mPerPx, -px[1] * mPerPx];
+}
+
+function numParam(p: URLSearchParams, key: string): number | undefined {
+  const raw = p.get(key);
+  if (raw === null || raw.trim() === '') return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export function parseViewState(search: string): ViewState {
+  const p = new URLSearchParams(search);
+  const state: ViewState = {};
+
+  const x = numParam(p, PARAM.x);
+  const y = numParam(p, PARAM.y);
+  if (x !== undefined && y !== undefined) state.center = [x, y];
+
+  const z = numParam(p, PARAM.z);
+  if (z !== undefined) state.zoom = z;
+
+  const group = p.get(PARAM.group);
+  const feature = p.get(PARAM.feature);
+  if (group && feature) state.feature = { group, feature };
+
+  const sample = p.get(PARAM.sample);
+  if (sample) state.sample = sample;
+
+  return state;
+}
+
+function setOrDelete(p: URLSearchParams, key: string, value: string | undefined) {
+  if (value === undefined) {
+    p.delete(key);
+  } else {
+    p.set(key, value);
+  }
+}
+
+/**
+ * Merge {@link state} into the existing query string, preserving unrelated
+ * params (notably the sample-loading `url`/`s` params).
+ */
+export function buildSearch(currentSearch: string, state: ViewState): string {
+  const p = new URLSearchParams(currentSearch);
+
+  setOrDelete(p, PARAM.x, state.center ? String(Math.round(state.center[0])) : undefined);
+  setOrDelete(p, PARAM.y, state.center ? String(Math.round(state.center[1])) : undefined);
+  setOrDelete(
+    p,
+    PARAM.z,
+    state.zoom !== undefined ? String(Math.round(state.zoom * 100) / 100) : undefined
+  );
+  setOrDelete(p, PARAM.group, state.feature?.group);
+  setOrDelete(p, PARAM.feature, state.feature?.feature);
+  setOrDelete(p, PARAM.sample, state.sample);
+
+  const s = p.toString();
+  return s ? `?${s}` : '';
+}
+
+function effectiveMPerPx(map: Mapp): number | undefined {
+  const ov = get(sOverlay);
+  return map.mPerPx ?? (ov ? get(overlays)[ov]?.coords?.mPerPx : undefined);
+}
+
+function activeFeature(): FeatureAndGroup | undefined {
+  const ov = get(sOverlay);
+  return ov ? get(overlaysFeature)[ov] : undefined;
+}
+
+/** A single map tile is the supported case for URL sync (see {@link UrlStateController}). */
+function singleTile(): boolean {
+  return get(mapTiles).length <= 1;
+}
+
+/**
+ * Two-way sync between the OpenLayers viewport and the URL query string.
+ *
+ * Restore order matters: the feature is applied on `sampleUpdated` (before the
+ * final render) so the right overlay loads, while center/zoom are applied on
+ * the first `renderComplete` (after `Mapp.updateSample` has fit the view).
+ * Writes are suppressed until restore finishes to avoid clobbering the URL.
+ *
+ * Only single-map mode is synced; in split-view the URL is left untouched.
+ */
+export class UrlStateController {
+  private pending: ViewState;
+  private featureRestored = false;
+  private sampleRestored = false;
+  private viewRestored = false;
+  private ready = false;
+  private moveEndKey?: EventsKey;
+  private unsubs: (() => void)[] = [];
+  private write = debounce(() => this.flush(), 300);
+
+  constructor(search: string) {
+    this.pending = parseViewState(search);
+  }
+
+  start() {
+    this.unsubs.push(sEvent.subscribe((e) => this.onEvent(e?.type)));
+
+    // The layout mounts after the map (Svelte fires child onMount first), so the
+    // first render events may already have passed. Restore against current state
+    // if a view has been fit (its center is set once Mapp.updateSample runs).
+    if (get(sMapp)?.map?.getView()?.getCenter()) {
+      this.attemptRestore();
+      this.attachMoveEnd();
+      this.ready = true;
+    }
+  }
+
+  stop() {
+    this.write.cancel();
+    this.unsubs.forEach((u) => u());
+    this.unsubs = [];
+    if (this.moveEndKey) unByKey(this.moveEndKey);
+    this.moveEndKey = undefined;
+  }
+
+  private onEvent(type?: string) {
+    if (type === 'sampleUpdated' || type === 'renderComplete') {
+      this.attemptRestore();
+      this.attachMoveEnd();
+    }
+
+    // The map has painted; further waiting is pointless. Open the write gate so
+    // user pans/zooms are recorded even if some state could not be restored.
+    if (type === 'renderComplete') this.ready = true;
+
+    if (this.ready && (type === 'featureUpdated' || type === 'sampleUpdated')) this.write();
+  }
+
+  private attemptRestore() {
+    this.restoreSample();
+    this.restoreFeature();
+    this.restoreView();
+    // Nothing left to restore -> begin tracking user changes immediately.
+    const needFeature = !!this.pending.feature && !this.featureRestored;
+    const needView =
+      (!!this.pending.center || this.pending.zoom !== undefined) && !this.viewRestored;
+    if (!needFeature && !needView) this.ready = true;
+  }
+
+  private restoreSample() {
+    if (this.sampleRestored || !this.pending.sample) return;
+    this.sampleRestored = true;
+    if (get(sSample)?.name === this.pending.sample) return;
+    if (get(samples).some((s) => s.name === this.pending.sample)) {
+      mapIdSample.update((m) => ({ ...m, [get(sMapId)]: this.pending.sample! }));
+    }
+  }
+
+  private restoreFeature() {
+    if (this.featureRestored || !this.pending.feature) return;
+    this.featureRestored = true;
+    setHoverSelect({ selected: this.pending.feature }).catch(console.error);
+  }
+
+  private restoreView() {
+    if (this.viewRestored) return;
+    const wantCenter = !!this.pending.center;
+    const wantZoom = this.pending.zoom !== undefined;
+    if (!wantCenter && !wantZoom) return;
+
+    const view = get(sMapp)?.map?.getView();
+    if (!view) return; // Map not mounted yet; retry on the next event.
+
+    let applied = false;
+    if (wantCenter) {
+      const mPerPx = effectiveMPerPx(get(sMapp)!);
+      if (!mPerPx) return; // Scale not known yet; retry without latching.
+      view.setCenter(pixelToMeter(this.pending.center!, mPerPx));
+      applied = true;
+    }
+    if (wantZoom) {
+      view.setZoom(this.pending.zoom!);
+      applied = true;
+    }
+    if (applied) this.viewRestored = true;
+  }
+
+  private attachMoveEnd() {
+    if (this.moveEndKey) return;
+    const map = get(sMapp);
+    if (!map?.map) return;
+    this.moveEndKey = map.map.on('moveend', () => {
+      if (this.ready) this.write();
+    });
+  }
+
+  private flush() {
+    if (!singleTile()) return;
+
+    const map = get(sMapp);
+    const view = map?.map?.getView();
+    if (!map || !view) return;
+
+    const state: ViewState = {};
+
+    const center = view.getCenter();
+    const mPerPx = effectiveMPerPx(map);
+    if (center && mPerPx) state.center = meterToPixel(center as [number, number], mPerPx);
+
+    const zoom = view.getZoom();
+    if (zoom !== undefined) state.zoom = zoom;
+
+    state.feature = activeFeature();
+
+    // Only disambiguate the sample when more than one is loaded.
+    const sample = get(sSample)?.name;
+    if (sample && get(samples).length > 1) state.sample = sample;
+
+    const search = buildSearch(window.location.search, state);
+    const url = `${window.location.pathname}${search}${window.location.hash}`;
+    history.replaceState(history.state, '', url);
+  }
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,6 +10,7 @@ import {
   sOverlay
 } from '$lib/store';
 import { handleError } from '$src/lib/utils';
+import { UrlStateController } from '$src/lib/ui/urlState';
 import { get } from 'svelte/store';
 import { onMount } from 'svelte';
 import '../app.css';
@@ -38,8 +39,12 @@ if (typeof window !== 'undefined') {
       document.body.dataset.renderComplete = evt?.type === 'renderComplete' ? 'true' : 'false';
     });
 
+    const urlState = new UrlStateController(window.location.search);
+    urlState.start();
+
     return () => {
       unsub();
+      urlState.stop();
       delete document.body.dataset.renderComplete;
       delete (window as any).__SAMUI__;
     };


### PR DESCRIPTION
## Problem

The viewer's state — map center, zoom, and the active overlay feature — lives only in memory. Reloading the page or sharing a link drops you back to the default fit and feature, so a particular view can't be bookmarked or sent to a collaborator. The app already reads `?url=`/`&s=` to load samples (`getSampleListFromQuery` in `src/lib/data/preload.ts`), but nothing round-trips the view itself.

## Fix

Add `src/lib/ui/urlState.ts`:

- Pure helpers `parseViewState` / `buildSearch` (plus `meterToPixel` / `pixelToMeter`), unit-tested in isolation.
- `UrlStateController`, which two-way-syncs the OpenLayers viewport with the query string, wired in `src/routes/+layout.svelte` (`start()` on mount, `stop()` on destroy).

New params ride alongside the existing `url`/`s`:

| param | meaning |
|-------|---------|
| `x`, `y` | map center in image pixels (uses the app's `sPixel` y-axis negation) |
| `z` | zoom |
| `g`, `f` | active feature group / name |

e.g. `…/from?url=data.samuibrowser.com/VisiumIF/&s=Br2720_Ant_IF&x=6000&y=6000&z=4.2&g=genes&f=SNAP25`

Lifecycle details the implementation respects:

- Feature is restored on `sampleUpdated` (before the final render) so the right overlay loads; center/zoom are restored on the first `renderComplete`, after `Mapp.updateSample` has fit the view.
- Writes are debounced and use `history.replaceState` (no history spam); the writer is gated until restore completes so it can't clobber the incoming URL.
- `url`/`s` are always preserved when the viewer params are written.

## Verification

- `src/lib/ui/urlState.test.ts` (13) — parse/build/round-trip, zero/empty-param edge cases, and the pixel↔meter sign convention.
- `e2e/urlState.spec.ts` (2) — load a state URL and assert the map restored to that center/zoom/feature; pan the map and assert `x`/`y`/`z` are written while `url`/`s` survive.
- `pnpm run test` (133 unit tests) and `pnpm run build` pass.

## Known limitations

- Only the active map tile is synced; in split-view the URL is intentionally left untouched.
- Center is rounded to whole image pixels and zoom to 2 decimals — sub-pixel / visually negligible, and keeps the URL short.
