### PR TITLE
Add Nextflow spatial-preprocessing module

### DIFF
--- a/loopy/feature.py
+++ b/loopy/feature.py
@@ -170,10 +170,15 @@ def sparse_compress_chunked_features(
     mode: Literal["csr", "csc"] = "csc",
     logger: Callback = log,
 ) -> tuple[ChunkedCSVHeader, bytearray]:
+    # Build the scipy sparse matrix without densifying: if every column is a
+    # pandas SparseDtype (e.g. a large gene-expression matrix), go via COO so we
+    # never materialize the dense array. A dense DataFrame falls back to the direct
+    # constructor, identical to the previous behaviour.
+    base = df.sparse.to_coo() if all(isinstance(dt, pd.SparseDtype) for dt in df.dtypes) else df
     if mode == "csr":
-        cs = csr_matrix(df)  # csR
+        cs = csr_matrix(base)  # csR
     elif mode == "csc":
-        cs = csc_matrix(df)  # csC
+        cs = csc_matrix(base)  # csC
     else:
         raise ValueError("Invalid mode")
 

--- a/loopy/spatial_io/__init__.py
+++ b/loopy/spatial_io/__init__.py
@@ -1,0 +1,68 @@
+"""Format registry and auto-detection for the spatial-platform readers.
+
+Each format module exposes `read(args) -> SpatialSample`. `get_reader` imports the
+module lazily so heavy per-format dependencies are only pulled when used.
+"""
+from __future__ import annotations
+
+import importlib
+from argparse import Namespace
+from pathlib import Path
+from typing import Callable
+
+from .common import SpatialSample  # re-exported for readers
+
+FORMATS = (
+    "xenium",
+    "visium",
+    "visium_hd",
+    "cosmx",
+    "spatialdata",
+    "files",
+)
+
+
+def get_reader(fmt: str) -> Callable[[Namespace], SpatialSample]:
+    """Return the `read` function of the module handling `fmt`.
+
+    The module is imported lazily so a format's heavy optional dependencies
+    (e.g. `spatialdata`) are only pulled in when that format is actually used.
+    """
+    if fmt not in FORMATS:
+        raise SystemExit(f"unknown --format '{fmt}'; choices: {', '.join(FORMATS)}, auto")
+    return importlib.import_module(f"loopy.spatial_io.{fmt}").read
+
+
+def detect_format(folder: Path) -> str:
+    """Sniff a folder for a platform signature. Raises if nothing matches.
+
+    Space Ranger nests its outputs under `outs/`; if the given folder is just a
+    wrapper around `outs/`, sniff that instead.
+    """
+    if (folder / "outs").is_dir() and not (folder / "spatial").is_dir():
+        only = [p.name for p in folder.iterdir() if not p.name.startswith(".")]
+        if only == ["outs"]:
+            folder = folder / "outs"
+
+    names = {p.name for p in folder.iterdir()}
+
+    def has_glob(pat: str) -> bool:
+        return any(folder.glob(pat))
+
+    if "experiment.xenium" in names or (
+        "cell_feature_matrix" in names and ("cells.parquet" in names or "cells.csv.gz" in names)
+    ):
+        return "xenium"
+    if "binned_outputs" in names or "segmented_outputs" in names or has_glob("square_0*um"):
+        return "visium_hd"
+    if "spatial" in names and (folder / "spatial").is_dir() and (
+        (folder / "spatial" / "tissue_positions.csv").exists()
+        or (folder / "spatial" / "tissue_positions_list.csv").exists()
+    ):
+        return "visium"
+    if has_glob("*_exprMat_file.csv") or has_glob("*exprMat*.csv"):
+        return "cosmx"
+    raise SystemExit(
+        f"could not auto-detect a spatial platform under {folder}. "
+        f"Pass --format explicitly (one of: {', '.join(FORMATS)})."
+    )

--- a/loopy/spatial_io/build.py
+++ b/loopy/spatial_io/build.py
@@ -1,0 +1,93 @@
+"""Turn a platform-agnostic `SpatialSample` into a loopy Sample folder.
+
+This is the glue between the readers and loopy: it drives loopy's `Sample`
+(`add_coords` / `add_chunked_feature` / `add_image` / `set_default_feature` /
+`write`) rather than re-implementing any of the coordinate join, chunked-feature
+compression or image tiling — loopy owns those.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+from loopy.sample import Sample
+
+from .common import FeatureGroup, SpatialSample
+
+
+def _check_overlap(fg: FeatureGroup, coord_index: pd.Index) -> None:
+    """Fail (or warn) on a feature group whose ids don't line up with the coords.
+
+    loopy's `add_chunked_feature` left-joins the feature frame onto the coordinate
+    table, silently dropping feature rows with no matching observation and leaving
+    NaN for observations absent from the feature. That is the behaviour we want,
+    but with no overlap at all it would emit an all-NaN feature instead of an
+    error, so guard that case here and warn on a partial match.
+    """
+    common = coord_index.intersection(fg.df.index)
+    if len(common) == 0:
+        sys.exit(
+            f"feature group '{fg.name}': no overlap with observation ids "
+            f"(obs e.g. {list(coord_index[:3])}, {fg.name} e.g. {list(fg.df.index[:3])})"
+        )
+    dropped = len(fg.df.index.difference(coord_index))
+    if dropped:
+        print(
+            f"warning: feature group '{fg.name}' has {dropped} ids not in coords; "
+            "loopy will drop them.",
+            file=sys.stderr,
+        )
+
+
+def build_sample(
+    s: SpatialSample,
+    *,
+    outdir: Path,
+    name: str,
+    convert_8bit: bool = False,
+) -> None:
+    """Write `s` as a loopy Sample folder at `outdir / name`.
+
+    Adds the coordinate set, each non-empty feature group (loopy joins it to the
+    coords and chunk-compresses it), and, if present, the background image
+    (degrading to image-less on any decode/IO failure rather than aborting the
+    run). Nothing is written until loopy's lazy `Sample.write()` at the end.
+    """
+    outdir.mkdir(parents=True, exist_ok=True)
+    if s.coords.index.duplicated().any():
+        sys.exit(f"duplicate observation ids in coords for sample '{name}'")
+
+    sample = Sample(name=name, path=outdir / name)
+    sample = sample.add_coords(
+        s.coords[["x", "y"]], name=s.coords_name, mPerPx=s.mpp, size=s.spot_size
+    )
+
+    for fg in s.features:
+        if fg.df.shape[1] == 0:
+            continue
+        _check_overlap(fg, s.coords.index)
+        sample = sample.add_chunked_feature(
+            fg.df, name=fg.name, coordName=s.coords_name,
+            sparse=fg.sparse, dataType=fg.data_type, unit=fg.unit,
+        )
+
+    has_image = False
+    if s.image is not None:
+        try:
+            sample.add_image(s.image, channels=s.channels, scale=s.mpp, convert_to_8bit=convert_8bit)
+            has_image = True
+        except Exception as e:  # noqa: BLE001 - any decode/IO failure should degrade, not abort
+            print(f"warning: could not add image {s.image}: {e}; continuing without it.", file=sys.stderr)
+
+    if s.default_feature:
+        sample = sample.set_default_feature(group=s.default_feature[0], feature=s.default_feature[1])
+
+    sample.write()
+    n_feat = sum(g.df.shape[1] for g in s.features)
+    print(
+        f"Wrote sample '{name}' to {outdir / name}\n"
+        f"  observations: {len(s.coords)}; feature groups: {len(s.features)} "
+        f"({n_feat} features); image: {'yes' if has_image else 'no'}"
+    )

--- a/loopy/spatial_io/common.py
+++ b/loopy/spatial_io/common.py
@@ -1,0 +1,216 @@
+"""Shared building blocks for the spatial-platform readers.
+
+Every reader turns a platform's files into one `SpatialSample`: a coordinate
+table keyed by a unique string observation id, zero or more named feature groups
+(expression / annotations / QC) keyed by that same id, and an optional image with
+its calibration. `build_sample` then turns that into a loopy Sample. The readers
+differ only in *where the bytes live and what units they are in*; the matrix
+decoders, control-feature filtering and id handling below are common to several
+platforms, so they live here rather than being re-implemented per platform.
+"""
+from __future__ import annotations
+
+import gzip
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, NoReturn
+
+import numpy as np
+import pandas as pd
+from scipy.io import mmread
+
+if TYPE_CHECKING:
+    import anndata
+
+GENE_EXPRESSION = "Gene Expression"
+# Control / background feature markers to drop when a feature-type column is absent
+# (Xenium carries a feature-type column; CosMx names its controls by prefix instead).
+CONTROL_NAME_PREFIXES = ("NegPrb", "NegControl", "SystemControl", "Blank-", "BLANK_", "blank-")
+
+
+@dataclass
+class FeatureGroup:
+    """One overlay group in Samui (a chunked feature)."""
+
+    name: str
+    df: pd.DataFrame  # observations (rows, str index) x features (columns)
+    data_type: str = "quantitative"  # or "categorical"
+    sparse: bool = False
+    unit: str | None = None
+
+
+@dataclass
+class SpatialSample:
+    """Platform-agnostic intermediate consumed by `build_sample`."""
+
+    coords: pd.DataFrame  # str index = observation id; columns x, y (pixels)
+    mpp: float  # meters per pixel, applied to coords and image
+    coords_name: str = "cells"
+    spot_size: float = 1e-5  # marker diameter in meters
+    features: list[FeatureGroup] = field(default_factory=list)
+    image: Path | None = None
+    channels: list[str] | None = None
+    default_feature: tuple[str, str] | None = None  # (group, feature)
+
+
+def fail(msg: str) -> NoReturn:
+    """Abort the run with `msg` as the process exit message (non-zero status)."""
+    sys.exit(msg)
+
+
+def as_str_index(obj: pd.Index | pd.Series | list) -> pd.Index:
+    """Coerce ids to a string-typed pandas Index (loopy requires string ids)."""
+    return pd.Index(obj).astype(str)
+
+
+def is_control_feature(name: str) -> bool:
+    """True if `name` is a negative/background probe (see `CONTROL_NAME_PREFIXES`)."""
+    return any(name.startswith(p) for p in CONTROL_NAME_PREFIXES)
+
+
+def drop_control_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop columns whose name marks a negative/background probe."""
+    keep = [c for c in df.columns if not is_control_feature(str(c))]
+    return df[keep]
+
+
+def read_mex(mex_dir: Path) -> tuple[pd.DataFrame, pd.Series]:
+    """Read a gzipped MatrixMarket triplet (features x cells) into obs x features.
+
+    Returns (counts, feature_types) where counts is observations x genes and
+    feature_types is a per-gene Series (the third features.tsv column, or NaN).
+    """
+    matrix = mex_dir / "matrix.mtx.gz"
+    features_file = mex_dir / "features.tsv.gz"
+    barcodes_file = mex_dir / "barcodes.tsv.gz"
+    for f in (matrix, features_file, barcodes_file):
+        if not f.exists():
+            fail(f"missing {f}")
+
+    features = pd.read_csv(features_file, sep="\t", header=None)
+    symbols = features[1] if features.shape[1] > 1 else features[0]
+    ftype = features[2] if features.shape[1] > 2 else pd.Series([np.nan] * len(features))
+    barcodes = pd.read_csv(barcodes_file, sep="\t", header=None)[0]
+
+    with gzip.open(matrix, "rb") as fh:
+        counts = mmread(fh).tocsc()  # features x cells (kept sparse)
+
+    # Sparse-backed frame (observations x features); densifying here would blow up
+    # for large panels (see read_10x_h5).
+    df = pd.DataFrame.sparse.from_spmatrix(
+        counts.T.tocsc(), index=as_str_index(barcodes), columns=list(symbols)
+    )
+    ftype.index = list(symbols)
+    return df, ftype
+
+
+def read_10x_h5(path: Path) -> tuple[pd.DataFrame, pd.Series]:
+    """Read a 10x CSC HDF5 matrix (/matrix, features x cells) into obs x features.
+
+    Returned as a sparse-backed DataFrame: densifying here would need tens of GB for
+    large panels (e.g. Xenium Prime, ~9.5k genes x ~400k cells), so the matrix stays
+    sparse all the way through `expression_group` and loopy's chunked-feature writer.
+    """
+    import h5py
+    from scipy.sparse import csc_matrix
+
+    with h5py.File(path, "r") as f:
+        g = f["matrix"]
+        data, indices, indptr = g["data"][:], g["indices"][:], g["indptr"][:]
+        shape = tuple(g["shape"][:])  # (n_features, n_obs)
+        mat = csc_matrix((data, indices, indptr), shape=shape)  # features x obs
+        barcodes = [b.decode() if isinstance(b, bytes) else str(b) for b in g["barcodes"][:]]
+        names = [n.decode() if isinstance(n, bytes) else str(n) for n in g["features"]["name"][:]]
+        ftype_raw = g["features"].get("feature_type")
+        ftype = (
+            [t.decode() if isinstance(t, bytes) else str(t) for t in ftype_raw[:]]
+            if ftype_raw is not None
+            else [np.nan] * len(names)
+        )
+
+    df = pd.DataFrame.sparse.from_spmatrix(mat.T.tocsc(), index=as_str_index(barcodes), columns=names)
+    return df, pd.Series(ftype, index=names)
+
+
+def expression_group(
+    counts: pd.DataFrame,
+    feature_types: pd.Series | None,
+    *,
+    name: str = "Gene expression",
+    unit: str = "counts",
+) -> FeatureGroup:
+    """Filter to biological genes and wrap as a sparse quantitative feature group."""
+    if feature_types is not None and feature_types.notna().any():
+        genes = feature_types.index[feature_types == GENE_EXPRESSION]
+        counts = counts.loc[:, counts.columns.isin(genes)]
+    counts = drop_control_columns(counts)
+    counts = counts.loc[:, ~counts.columns.duplicated()]
+    return FeatureGroup(name=name, df=counts, data_type="quantitative", sparse=True, unit=unit)
+
+
+def read_10x_clusters(analysis_dir: Path) -> "FeatureGroup | None":
+    """Collect 10x `analysis/clustering/*/clusters.csv` into one categorical group.
+
+    Shared by Xenium / Visium / Visium HD, whose clustering dirs are named
+    `graphclust` / `kmeans_N_clusters` (Xenium prefixes them `gene_expression_`).
+    """
+    clustering = analysis_dir / "clustering"
+    if not clustering.is_dir():
+        return None
+    cols = {}
+    for sub in sorted(clustering.iterdir()):
+        csv = sub / "clusters.csv"
+        if not csv.exists():
+            continue
+        name = sub.name.removeprefix("gene_expression_").removesuffix("_clusters")
+        df = pd.read_csv(csv)
+        cols[name] = pd.Series(df["Cluster"].astype(str).to_numpy(), index=as_str_index(df["Barcode"]))
+    if not cols:
+        return None
+    return FeatureGroup("Clusters", pd.DataFrame(cols), data_type="categorical")
+
+
+def read_anndata(path: Path) -> "anndata.AnnData":
+    """Read an `.h5ad` file into an AnnData (imported lazily to keep it optional)."""
+    import anndata as ad
+
+    return ad.read_h5ad(path)
+
+
+def anndata_to_sample(
+    adata: "anndata.AnnData",
+    *,
+    mpp: float,
+    coords_name: str,
+    spot_size: float,
+    spatial_key: str = "spatial",
+) -> SpatialSample:
+    """Convert an AnnData table to a `SpatialSample` (used by the SpatialData reader).
+
+    Coordinates come from `obsm[spatial_key]` (first two columns), expression from
+    `X` (filtered to genes and wrapped as one sparse quantitative group), and the
+    categorical/object `obs` columns become a single categorical Annotations group.
+    """
+    obs_ids = as_str_index(adata.obs_names)
+    if spatial_key not in adata.obsm:
+        fail(f"AnnData has no obsm['{spatial_key}']; cannot place observations")
+    xy = np.asarray(adata.obsm[spatial_key])[:, :2]
+    coords = pd.DataFrame({"x": xy[:, 0], "y": xy[:, 1]}, index=obs_ids)
+
+    # Keep a sparse X sparse-backed (see read_10x_h5); a dense X stays dense.
+    var_names = as_str_index(adata.var_names)
+    X = adata.X
+    if hasattr(X, "toarray"):  # scipy sparse
+        expr = pd.DataFrame.sparse.from_spmatrix(X, index=obs_ids, columns=var_names)
+    else:
+        expr = pd.DataFrame(np.asarray(X), index=obs_ids, columns=var_names)
+    groups = [expression_group(expr, None)]
+
+    cat = [c for c in adata.obs.columns if str(adata.obs[c].dtype) in ("category", "object")]
+    if cat:
+        ann = adata.obs[cat].astype(str)
+        ann.index = obs_ids
+        groups.append(FeatureGroup("Annotations", ann, data_type="categorical"))
+
+    return SpatialSample(coords=coords, mpp=mpp, coords_name=coords_name, spot_size=spot_size, features=groups)

--- a/loopy/spatial_io/cosmx.py
+++ b/loopy/spatial_io/cosmx.py
@@ -1,0 +1,89 @@
+"""CosMx SMI (NanoString / Bruker) flat-file reader. Coordinates in global mosaic pixels.
+
+Observations are cells, identified by the (fov, cell_ID) pair; cell_ID 0 marks
+background and is dropped. The same composite "{fov}_{cell_ID}" id keys both the
+expression matrix and the per-cell metadata, so the two tables join on it.
+"""
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+import pandas as pd
+
+from .common import FeatureGroup, SpatialSample, as_str_index, expression_group, fail
+
+# CosMx SMI imaging pixel size; the legacy flat-file export carries no calibration.
+DEFAULT_PIXEL_SIZE = 0.12028  # microns/px
+# Column-name aliases across export vintages (legacy lowercases fov / mixed-cases cell_ID).
+FOV_ALIASES = ("fov", "FOV", "Fov")
+CELL_ALIASES = ("cell_ID", "cell_id", "cellID", "CellId", "Cell_ID")
+X_ALIASES = ("CenterX_global_px", "CenterX_global", "x_global_px")
+Y_ALIASES = ("CenterY_global_px", "CenterY_global", "y_global_px")
+
+
+def _one(folder: Path, pattern: str) -> Path | None:
+    """Return the first file in `folder` matching `pattern` (sorted), or None."""
+    hits = sorted(folder.glob(pattern))
+    return hits[0] if hits else None
+
+
+def _pick(df: pd.DataFrame, aliases: tuple[str, ...], what: str) -> str:
+    """Return the first of `aliases` present as a column, or fail naming `what`."""
+    for name in aliases:
+        if name in df.columns:
+            return name
+    fail(f"no {what} column (tried {aliases}); found {list(df.columns)}")
+
+
+def _composite_id(df: pd.DataFrame, fov_col: str, cell_col: str) -> pd.Index:
+    """Build the unique observation id `{fov}_{cell_ID}` for each row."""
+    return as_str_index(df[fov_col].astype(str) + "_" + df[cell_col].astype(str))
+
+
+def read(args: Namespace) -> SpatialSample:
+    """Read a CosMx SMI flat-file export into a `SpatialSample`.
+
+    Observations are cells keyed by `{fov}_{cell_ID}` (background cell_ID 0 dropped);
+    coordinates are the global-pixel centroids, feature groups are gene expression
+    (control probes filtered by name) and any numeric per-cell metrics.
+    """
+    folder = args.folder
+    if not folder or not folder.is_dir():
+        fail("cosmx format requires --folder pointing at a CosMx SMI flat-file export")
+    expr_file = _one(folder, "*_exprMat_file.csv")
+    meta_file = _one(folder, "*_metadata_file.csv")
+    if expr_file is None or meta_file is None:
+        fail(f"missing *_exprMat_file.csv / *_metadata_file.csv in {folder}")
+
+    expr = pd.read_csv(expr_file)
+    e_fov = _pick(expr, FOV_ALIASES, "fov")
+    e_cell = _pick(expr, CELL_ALIASES, "cell id")
+    expr = expr[expr[e_cell] != 0]
+    expr.index = _composite_id(expr, e_fov, e_cell)
+    counts = expr.drop(columns=[e_fov, e_cell])
+    genes = expression_group(counts, None)  # drops NegPrb*/SystemControl* via control-name filter
+
+    meta = pd.read_csv(meta_file)
+    m_fov = _pick(meta, FOV_ALIASES, "fov")
+    m_cell = _pick(meta, CELL_ALIASES, "cell id")
+    m_x = _pick(meta, X_ALIASES, "global x")
+    m_y = _pick(meta, Y_ALIASES, "global y")
+    meta = meta[meta[m_cell] != 0]
+    meta.index = _composite_id(meta, m_fov, m_cell)
+    coords = pd.DataFrame({"x": meta[m_x], "y": meta[m_y]}, index=meta.index)
+
+    features = [genes]
+    metrics = meta.select_dtypes(include="number").drop(
+        columns=[m_fov, m_cell, m_x, m_y], errors="ignore"
+    )
+    if metrics.shape[1]:
+        features.append(FeatureGroup("Cell metrics", metrics, data_type="quantitative"))
+
+    return SpatialSample(
+        coords=coords,
+        mpp=(args.pixel_size * 1e-6) if args.pixel_size else DEFAULT_PIXEL_SIZE * 1e-6,
+        coords_name="cells",
+        spot_size=args.spot_size or 10e-6,
+        features=features,
+    )

--- a/loopy/spatial_io/files.py
+++ b/loopy/spatial_io/files.py
@@ -1,0 +1,133 @@
+"""Individual-file mode: image + cell annotations (obs) + feature annotations (var)
++ cell-feature annotations (the expression matrix X), joined by observation id.
+
+Coordinates live in the cell-annotations table. This is the AnnData decomposition
+expressed as separate files; the SpatialData reader reuses the same shape in memory.
+"""
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+import pandas as pd
+
+from .common import (
+    FeatureGroup,
+    SpatialSample,
+    as_str_index,
+    drop_control_columns,
+    expression_group,
+    fail,
+    read_10x_h5,
+    read_mex,
+)
+
+ID_ALIASES = ("id", "cell_id", "barcode", "cell", "obs", "observation_id")
+X_ALIASES = ("x", "x_centroid", "center_x", "px_x", "pxl_col_in_fullres")
+Y_ALIASES = ("y", "y_centroid", "center_y", "px_y", "pxl_row_in_fullres")
+
+
+def _read_table(path: Path) -> pd.DataFrame:
+    """Read a CSV or Parquet table into a DataFrame."""
+    if path.suffix == ".parquet":
+        return pd.read_parquet(path)
+    return pd.read_csv(path)
+
+
+def _pick(cols: dict[str, str], aliases: tuple[str, ...]) -> str | None:
+    """Map the first matching lowercase alias to its original column name, or None."""
+    for a in aliases:
+        if a in cols:
+            return cols[a]
+    return None
+
+
+def _read_cells(path: Path) -> tuple[pd.DataFrame, list[FeatureGroup]]:
+    """Read the cell table into coordinates plus overlay groups.
+
+    Picks an id column (or uses the row number), x/y coordinate columns (accepting
+    the aliases in `X_ALIASES`/`Y_ALIASES`), and turns the remaining columns into a
+    categorical Annotations group (text) and a quantitative Cell metrics group (numeric).
+    """
+    df = _read_table(path)
+    cols = {c.lower(): c for c in df.columns}
+    id_col = _pick(cols, ID_ALIASES)
+    if id_col is not None:
+        df = df.set_index(id_col)
+    df.index = as_str_index(df.index)
+
+    xcol, ycol = _pick(cols, X_ALIASES), _pick(cols, Y_ALIASES)
+    if not xcol or not ycol:
+        fail(f"cell-annotations file {path} needs x/y columns; found {list(df.columns)}")
+    coords = pd.DataFrame({"x": df[xcol], "y": df[ycol]}, index=df.index)
+
+    rest = df.drop(columns=[xcol, ycol])
+    groups = []
+    cat = rest.select_dtypes(exclude="number")
+    if cat.shape[1]:
+        groups.append(FeatureGroup("Annotations", cat.astype(str), data_type="categorical"))
+    num = rest.select_dtypes(include="number")
+    if num.shape[1]:
+        groups.append(FeatureGroup("Cell metrics", num, data_type="quantitative"))
+    return coords, groups
+
+
+def _read_matrix(path: Path, obs_index: pd.Index) -> pd.DataFrame:
+    """Read the expression matrix as observations x features.
+
+    Accepts a MEX directory, a 10x `.h5`, or a CSV/Parquet table; for the tabular
+    forms the orientation is detected by matching either axis against `obs_index`,
+    so a transposed (features x observations) matrix is handled.
+    """
+    if path.is_dir():
+        counts, _ = read_mex(path)
+        return counts
+    if path.suffix == ".h5":
+        counts, _ = read_10x_h5(path)
+        return counts
+    if path.suffix == ".parquet":
+        df = pd.read_parquet(path)
+        df = df.set_index(df.columns[0])
+    else:
+        df = pd.read_csv(path, index_col=0)
+    df.index = as_str_index(df.index)
+    # Orient so rows are observations: pick whichever axis matches the cell ids.
+    if df.index.isin(obs_index).sum() < as_str_index(df.columns).isin(obs_index).sum():
+        df = df.T
+        df.index = as_str_index(df.index)
+    return df
+
+
+def read(args: Namespace) -> SpatialSample:
+    """Read the individual-file (AnnData decomposition) inputs into a `SpatialSample`.
+
+    Joins `--cells` (coordinates + obs) with `--matrix` (expression X) by observation
+    id, optionally restricting to gene features via `--features` (var) and attaching
+    `--image` as the background.
+    """
+    if not args.cells or not args.matrix:
+        fail("files format requires --cells and --matrix (and optional --image, --features)")
+    coords, extra_groups = _read_cells(args.cells)
+    counts = _read_matrix(args.matrix, coords.index)
+
+    ftype = None
+    if args.features:
+        var = _read_table(args.features)
+        var = var.set_index(var.columns[0])
+        type_col = next((c for c in var.columns if "type" in c.lower()), None)
+        if type_col is not None:
+            ftype = var[type_col]
+            ftype.index = as_str_index(var.index)
+            counts.columns = as_str_index(counts.columns)
+    counts = drop_control_columns(counts)
+    groups = [expression_group(counts, ftype)] + extra_groups
+
+    return SpatialSample(
+        coords=coords,
+        mpp=args.mpp if args.mpp is not None else 1.0,
+        coords_name="cells",
+        spot_size=args.spot_size if args.spot_size is not None else 1e-5,
+        features=groups,
+        image=args.image,
+        channels=None,
+    )

--- a/loopy/spatial_io/files.py
+++ b/loopy/spatial_io/files.py
@@ -124,7 +124,7 @@ def read(args: Namespace) -> SpatialSample:
 
     return SpatialSample(
         coords=coords,
-        mpp=args.mpp if args.mpp is not None else 1.0,
+        mpp=args.mpp if args.mpp is not None else 1e-6,
         coords_name="cells",
         spot_size=args.spot_size if args.spot_size is not None else 1e-5,
         features=groups,

--- a/loopy/spatial_io/preprocess.py
+++ b/loopy/spatial_io/preprocess.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Preprocess a spatial dataset into a Samui sample folder.
+
+One entrypoint, three input modes selected by --format:
+  - a named platform (xenium, visium, visium_hd, cosmx) read from a --folder, or
+    `auto` to detect the platform from it;
+  - `spatialdata` from a SpatialData --zarr (.zarr.zip or .zarr directory);
+  - `files` from individual --image / --cells / --features / --matrix files.
+
+Every mode produces the same intermediate (coordinates + feature groups + image)
+which is written as sample.json plus the image/coords/feature assets. The Samui viewer
+that opens this folder is co-hosted alongside it by the workflow (see modules/site.nf).
+
+Installed as the `preprocess` console script; the Nextflow module invokes it.
+"""
+import argparse
+from pathlib import Path
+
+from loopy.spatial_io import detect_format, get_reader
+from loopy.spatial_io.build import build_sample
+
+
+def main() -> None:
+    """Parse CLI arguments, dispatch to the format reader, apply overrides, and build the sample."""
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--format", required=True, help="platform/mode, or 'auto' to detect from --folder")
+    p.add_argument("--outdir", type=Path, required=True, help="parent directory of the sample folder")
+    p.add_argument("--sample-name", required=True)
+
+    # Input sources (which one is used depends on --format).
+    p.add_argument("--folder", type=Path, help="platform output directory (named platform or auto)")
+    p.add_argument("--zarr", type=Path, help="SpatialData .zarr.zip or .zarr directory")
+    p.add_argument("--image", type=Path, help="files mode: TIFF/OME-TIFF image")
+    p.add_argument("--cells", type=Path, help="files mode: per-cell table (coordinates + labels)")
+    p.add_argument("--features", type=Path, help="files mode: per-feature (gene) metadata table")
+    p.add_argument("--matrix", type=Path, help="files mode: expression matrix (cells x features)")
+
+    # Calibration / presentation overrides (each reader sets sensible defaults).
+    p.add_argument("--mpp", type=float, default=None, help="meters per pixel (overrides platform value)")
+    p.add_argument("--pixel-size", type=float, default=None, help="microns per pixel (imaging platforms)")
+    p.add_argument("--spot-size", type=float, default=None, help="marker diameter in meters")
+    p.add_argument("--coords-name", default=None, help="name of the coordinate set")
+    p.add_argument("--default-feature", default=None, help="feature shown by default on load")
+
+    # Image / output.
+    p.add_argument("--convert-8bit", action="store_true", help="downcast the image to 8-bit")
+    p.add_argument("--no-image", action="store_true", help="skip the background image")
+    args = p.parse_args()
+
+    fmt = args.format
+    if fmt == "auto":
+        if not args.folder:
+            p.error("--format auto requires --folder")
+        fmt = detect_format(args.folder)
+        print(f"auto-detected format: {fmt}")
+
+    sample = get_reader(fmt)(args)
+
+    # Apply explicit CLI overrides on top of the reader's defaults.
+    if args.mpp is not None:
+        sample.mpp = args.mpp
+    if args.spot_size is not None:
+        sample.spot_size = args.spot_size
+    if args.coords_name:
+        sample.coords_name = args.coords_name
+    if args.no_image:
+        sample.image = None
+    if args.default_feature and sample.features:
+        group = next((g.name for g in sample.features if g.data_type == "quantitative"), sample.features[0].name)
+        sample.default_feature = (group, args.default_feature)
+
+    build_sample(
+        sample,
+        outdir=args.outdir,
+        name=args.sample_name,
+        convert_8bit=args.convert_8bit,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/loopy/spatial_io/spatialdata.py
+++ b/loopy/spatial_io/spatialdata.py
@@ -1,0 +1,153 @@
+"""SpatialData (.zarr / .zarr.zip) reader.
+
+A SpatialData store bundles images, labels, shapes, points and one or more
+AnnData tables in a single Zarr group. We export the single (or first) table as
+the observation set: expression from ``X``, categorical ``obs`` as annotations,
+and per-observation coordinates from either the table's ``obsm['spatial']`` or
+the centroids of the matching ``shapes`` element joined on the table's
+instance key.
+
+Coordinates live in the element's coordinate system (microns for the test
+stores), so ``mpp`` defaults to 1e-6 m/px unless ``--pixel_size`` overrides it.
+
+Image export is out of scope here: SpatialData images are multiscale dask
+arrays, so writing them to TIFF (a future extension) would mean rasterizing a
+chosen scale/coordinate-system. ``image`` is left None for now.
+"""
+from __future__ import annotations
+
+import tempfile
+import zipfile
+from argparse import Namespace
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Generator
+
+import numpy as np
+import pandas as pd
+
+from .common import (
+    FeatureGroup,
+    SpatialSample,
+    anndata_to_sample,
+    as_str_index,
+    expression_group,
+    fail,
+)
+
+if TYPE_CHECKING:
+    import anndata
+    import spatialdata as sd
+
+DEFAULT_MPP = 1e-6  # meters/px when no pixel_size is given (coords assumed in microns)
+DEFAULT_SPOT_SIZE = 1e-5  # marker diameter in meters
+
+
+@contextmanager
+def _opened_store(path: Path) -> Generator[Path, None, None]:
+    """Yield a directory path that ``sd.read_zarr`` can open.
+
+    A ``.zarr`` directory is used in place; a ``.zarr.zip`` is extracted to a
+    temporary directory first (read_zarr expects a directory store).
+    """
+    if path.is_dir():
+        yield path
+        return
+    if path.suffix == ".zip" or zipfile.is_zipfile(path):
+        with tempfile.TemporaryDirectory() as tmp:
+            with zipfile.ZipFile(path) as zf:
+                zf.extractall(tmp)
+            extracted = Path(tmp)
+            # Zips may wrap the store in a single top-level directory.
+            entries = [p for p in extracted.iterdir() if not p.name.startswith(".")]
+            if len(entries) == 1 and entries[0].is_dir():
+                extracted = entries[0]
+            yield extracted
+        return
+    fail(f"spatialdata format requires a .zarr directory or .zarr.zip file; got {path}")
+
+
+def _coords_from_shapes(sdata: "sd.SpatialData", table: "anndata.AnnData") -> pd.DataFrame | None:
+    """Centroids of the table's region shapes, indexed by the instance key."""
+    attrs = table.uns.get("spatialdata_attrs", {})
+    region = attrs.get("region")
+    instance_key = attrs.get("instance_key")
+    if not region or not instance_key or instance_key not in table.obs:
+        return None
+    regions = [region] if isinstance(region, str) else list(region)
+    shape_names = [r for r in regions if r in sdata.shapes]
+    if not shape_names:
+        return None
+
+    geoms = pd.concat([sdata.shapes[r].geometry for r in shape_names])
+    centroids = geoms.centroid
+    by_instance = pd.Series(
+        {str(i): (g.x, g.y) for i, g in zip(centroids.index, centroids)}
+    )
+
+    instances = as_str_index(table.obs[instance_key])
+    missing = instances.difference(by_instance.index)
+    if len(missing):
+        fail(
+            f"{len(missing)} table observations have no matching shape in "
+            f"{shape_names}; cannot place them"
+        )
+    xy = np.array([by_instance[i] for i in instances])
+    return pd.DataFrame({"x": xy[:, 0], "y": xy[:, 1]}, index=instances)
+
+
+def read(args: Namespace) -> SpatialSample:
+    """Read a SpatialData `.zarr` / `.zarr.zip` store into a `SpatialSample`.
+
+    Exports the single (or first) AnnData table: expression from `X`, categorical
+    `obs` as annotations, and coordinates from the table's `obsm['spatial']` or, if
+    absent, the centroids of the matching `shapes` element joined on the instance key.
+    Images are not exported (see the module docstring).
+    """
+    import spatialdata as sd
+
+    path = Path(args.zarr)
+    mpp = (args.pixel_size * 1e-6) if args.pixel_size else DEFAULT_MPP
+    spot_size = args.spot_size or DEFAULT_SPOT_SIZE
+
+    with _opened_store(path) as store:
+        sdata = sd.read_zarr(store)
+
+        if not sdata.tables:
+            fail(f"SpatialData store {path} has no tables; nothing to export")
+        table_key, table = next(iter(sdata.tables.items()))
+        region = table.uns.get("spatialdata_attrs", {}).get("region")
+        coords_name = region if isinstance(region, str) else table_key
+
+        if "spatial" in table.obsm:
+            return anndata_to_sample(
+                table, mpp=mpp, coords_name=coords_name, spot_size=spot_size
+            )
+
+        coords = _coords_from_shapes(sdata, table)
+        if coords is None:
+            fail(
+                "table has no obsm['spatial'] and no matching shapes element; "
+                "labels-based centroid fallback is not implemented"
+            )
+
+        obs_ids = coords.index
+        mat = table.X
+        if hasattr(mat, "toarray"):
+            mat = mat.toarray()
+        expr = pd.DataFrame(np.asarray(mat), index=obs_ids, columns=as_str_index(table.var_names))
+        groups = [expression_group(expr, None)]
+
+        cat = [c for c in table.obs.columns if str(table.obs[c].dtype) in ("category", "object")]
+        if cat:
+            ann = table.obs[cat].astype(str)
+            ann.index = obs_ids
+            groups.append(FeatureGroup("Annotations", ann, data_type="categorical"))
+
+        return SpatialSample(
+            coords=coords,
+            mpp=mpp,
+            coords_name=coords_name,
+            spot_size=spot_size,
+            features=groups,
+        )

--- a/loopy/spatial_io/spatialdata.py
+++ b/loopy/spatial_io/spatialdata.py
@@ -67,6 +67,29 @@ def _opened_store(path: Path) -> Generator[Path, None, None]:
     fail(f"spatialdata format requires a .zarr directory or .zarr.zip file; got {path}")
 
 
+def _read_zarr_sanitized(store: Path) -> "sd.SpatialData":
+    """Read a store whose table keys violate spatialdata's naming rules.
+
+    spatialdata >=0.7 validates element/column names at ``SpatialData``
+    construction, rejecting otherwise-valid stores whose ``obs``/``var`` names
+    contain characters outside ``[A-Za-z0-9_.-]`` (e.g. 'µm', '^2', 'a/b').
+    Read the non-table elements normally, then attach each table after
+    running it through spatialdata's own sanitizer, which replaces invalid
+    characters with underscores (and de-duplicates any resulting collisions).
+    """
+    import anndata as ad
+    import spatialdata as sd
+
+    sdata = sd.read_zarr(store, selection=("images", "labels", "points", "shapes"))
+    tables_dir = store / "tables"
+    if tables_dir.is_dir():
+        for table_dir in sorted(p for p in tables_dir.iterdir() if p.is_dir()):
+            table = ad.read_zarr(table_dir)
+            sd.sanitize_table(table, inplace=True)
+            sdata.tables[table_dir.name] = table
+    return sdata
+
+
 def _coords_from_shapes(sdata: "sd.SpatialData", table: "anndata.AnnData") -> pd.DataFrame | None:
     """Centroids of the table's region shapes, indexed by the instance key."""
     attrs = table.uns.get("spatialdata_attrs", {})
@@ -105,13 +128,17 @@ def read(args: Namespace) -> SpatialSample:
     Images are not exported (see the module docstring).
     """
     import spatialdata as sd
+    from spatialdata._core.validation import ValidationError
 
     path = Path(args.zarr)
     mpp = (args.pixel_size * 1e-6) if args.pixel_size else DEFAULT_MPP
     spot_size = args.spot_size or DEFAULT_SPOT_SIZE
 
     with _opened_store(path) as store:
-        sdata = sd.read_zarr(store)
+        try:
+            sdata = sd.read_zarr(store)
+        except ValidationError:
+            sdata = _read_zarr_sanitized(store)
 
         if not sdata.tables:
             fail(f"SpatialData store {path} has no tables; nothing to export")

--- a/loopy/spatial_io/visium.py
+++ b/loopy/spatial_io/visium.py
@@ -1,0 +1,128 @@
+"""10x Visium (Space Ranger) reader. Coordinates in full-resolution image pixels."""
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import pandas as pd
+
+from .common import (
+    FeatureGroup,
+    SpatialSample,
+    as_str_index,
+    expression_group,
+    fail,
+    read_10x_clusters,
+    read_10x_h5,
+    read_mex,
+)
+
+SPOT_DIAMETER_UM = 55.0  # a Visium spot is 55 microns across
+# tissue_positions columns, in Space Ranger's fixed order
+POSITION_COLUMNS = [
+    "barcode", "in_tissue", "array_row", "array_col",
+    "pxl_row_in_fullres", "pxl_col_in_fullres",
+]
+
+
+def _outs(folder: Path) -> Path:
+    """Locate the directory holding spatial/ (the run dir or its outs/ subdir)."""
+    if (folder / "spatial").is_dir():
+        return folder
+    if (folder / "outs" / "spatial").is_dir():
+        return folder / "outs"
+    fail(f"no spatial/ directory found in {folder} or {folder}/outs")
+
+
+def _expression(outs: Path) -> FeatureGroup:
+    """Read the filtered feature-barcode matrix (.h5 or MEX dir) as a feature group."""
+    h5 = outs / "filtered_feature_bc_matrix.h5"
+    mex = outs / "filtered_feature_bc_matrix"
+    if h5.exists():
+        counts, ftype = read_10x_h5(h5)
+    elif mex.is_dir():
+        counts, ftype = read_mex(mex)
+    else:
+        fail(f"missing filtered_feature_bc_matrix.h5 / filtered_feature_bc_matrix/ in {outs}")
+    return expression_group(counts, ftype)
+
+
+def _positions(spatial: Path) -> pd.DataFrame:
+    """Read tissue_positions (parquet / headered csv / legacy list), normalized to `POSITION_COLUMNS`."""
+    parquet = spatial / "tissue_positions.parquet"
+    csv_headered = spatial / "tissue_positions.csv"
+    csv_legacy = spatial / "tissue_positions_list.csv"
+    if parquet.exists():
+        df = pd.read_parquet(parquet)
+    elif csv_headered.exists():
+        df = pd.read_csv(csv_headered)
+    elif csv_legacy.exists():
+        with csv_legacy.open() as fh:
+            first = fh.readline()
+        header = "infer" if first.startswith("barcode") else None
+        df = pd.read_csv(csv_legacy, header=header)
+    else:
+        fail(f"missing tissue_positions(.parquet/.csv/_list.csv) in {spatial}")
+
+    if list(df.columns)[: len(POSITION_COLUMNS)] != POSITION_COLUMNS:
+        df = df.iloc[:, : len(POSITION_COLUMNS)]
+        df.columns = POSITION_COLUMNS
+    return df
+
+
+def _calibration(spatial: Path, override: float | None) -> float:
+    """Return microns/pixel, from --pixel_size or the spot-diameter scalefactor."""
+    if override is not None:
+        return override
+    scale_file = spatial / "scalefactors_json.json"
+    if not scale_file.exists():
+        fail(f"missing scalefactors_json.json in {spatial} and no --pixel_size given")
+    diameter_px = json.loads(scale_file.read_text()).get("spot_diameter_fullres")
+    if not diameter_px:
+        fail("scalefactors_json.json has no usable spot_diameter_fullres")
+    return SPOT_DIAMETER_UM / float(diameter_px)
+
+
+def read(args: Namespace) -> SpatialSample:
+    """Read a 10x Visium (Space Ranger) output directory into a `SpatialSample`.
+
+    Coordinates are the in-tissue spots' full-resolution pixel positions; feature
+    groups are gene expression and 10x clusters (if present). No image is attached
+    (Visium's tissue image is not part of the required outputs).
+    """
+    folder = args.folder
+    if not folder or not folder.is_dir():
+        fail("visium format requires --folder pointing at a Space Ranger output directory")
+
+    outs = _outs(folder)
+    spatial = outs / "spatial"
+
+    positions = _positions(spatial)
+    positions = positions[positions["in_tissue"] == 1]
+    if positions.empty:
+        fail("no in-tissue spots found in tissue positions")
+    coords = pd.DataFrame(
+        {
+            "x": positions["pxl_col_in_fullres"].astype(float).to_numpy(),
+            "y": positions["pxl_row_in_fullres"].astype(float).to_numpy(),
+        },
+        index=as_str_index(positions["barcode"]),
+    )
+
+    microns_per_px = _calibration(spatial, args.pixel_size)
+
+    features = [_expression(outs)]
+    clusters = read_10x_clusters(outs / "analysis")
+    if clusters is not None:
+        features.append(clusters)
+
+    return SpatialSample(
+        coords=coords,
+        mpp=microns_per_px * 1e-6,
+        coords_name="spots",
+        spot_size=SPOT_DIAMETER_UM * 1e-6,
+        features=features,
+        image=None,
+        channels=None,
+    )

--- a/loopy/spatial_io/visium_hd.py
+++ b/loopy/spatial_io/visium_hd.py
@@ -1,0 +1,110 @@
+"""10x Visium HD reader (Space Ranger v4.0+).
+
+Uses the binned outputs at the coarsest available bin (prefer square_016um, else
+008, else 002) to keep the published sample a manageable size. Coordinates come
+from `spatial/tissue_positions.parquet` in full-res image pixels; calibration uses
+the `microns_per_pixel` key in `scalefactors_json.json`.
+
+Segmented single cells (`segmented_outputs/`) are a possible future extension: it
+would require parsing `cell_segmentations.geojson` centroids and mapping the integer
+geojson cell ids to the matrix barcodes (`cellid_00000000N-1`). Not implemented here.
+"""
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import pandas as pd
+
+from .common import (
+    FeatureGroup,
+    SpatialSample,
+    as_str_index,
+    expression_group,
+    fail,
+    read_10x_clusters,
+    read_10x_h5,
+)
+
+BIN_PREFERENCE = ("square_016um", "square_008um", "square_002um")
+
+
+def _bin_dir(folder: Path) -> Path:
+    """Return the coarsest available bin directory under binned_outputs/ (see `BIN_PREFERENCE`)."""
+    binned = folder / "binned_outputs"
+    if not binned.is_dir():
+        fail(f"visium_hd format requires binned_outputs/ under {folder}")
+    for name in BIN_PREFERENCE:
+        cand = binned / name
+        if cand.is_dir():
+            return cand
+    fail(f"no recognized bin directory in {binned}; expected one of {BIN_PREFERENCE}")
+
+
+def _calibration(bin_dir: Path, bin_size_um: float, override: float | None) -> float:
+    """Return microns/pixel for this bin from scalefactors_json.json (or override)."""
+    if override is not None:
+        return override
+    sf = bin_dir / "spatial" / "scalefactors_json.json"
+    if not sf.exists():
+        fail(f"missing {sf}")
+    data = json.loads(sf.read_text())
+    if "microns_per_pixel" in data:
+        return float(data["microns_per_pixel"])
+    if "spot_diameter_fullres" in data:
+        # spot_diameter_fullres is the bin pitch in full-res pixels.
+        return bin_size_um / float(data["spot_diameter_fullres"])
+    fail(f"scalefactors_json.json has neither microns_per_pixel nor spot_diameter_fullres: {sf}")
+
+
+def _coords(bin_dir: Path) -> pd.DataFrame:
+    """Read in-tissue bin coordinates (full-res pixels) from the bin's tissue_positions.parquet."""
+    positions = bin_dir / "spatial" / "tissue_positions.parquet"
+    if not positions.exists():
+        fail(f"missing {positions}")
+    df = pd.read_parquet(positions)
+    df = df[df["in_tissue"] == 1]
+    if df.empty:
+        fail(f"no in_tissue bins in {positions}")
+    return pd.DataFrame(
+        {"x": df["pxl_col_in_fullres"].to_numpy(), "y": df["pxl_row_in_fullres"].to_numpy()},
+        index=as_str_index(df["barcode"]),
+    )
+
+
+def read(args: Namespace) -> SpatialSample:
+    """Read a 10x Visium HD output directory into a `SpatialSample`.
+
+    Uses the coarsest available bin (see `BIN_PREFERENCE`); coordinates are the
+    in-tissue bins' full-resolution pixel positions, feature groups are gene
+    expression and 10x clusters (if present). No image is attached.
+    """
+    folder = args.folder
+    if not folder or not folder.is_dir():
+        fail("visium_hd format requires --folder pointing at a Space Ranger output directory")
+
+    bin_dir = _bin_dir(folder)
+    bin_size_um = float(bin_dir.name.removeprefix("square_").removesuffix("um"))
+    print(f"visium_hd: using bin {bin_dir.name} (microns_per_pixel from scalefactors_json.json)")
+
+    h5 = bin_dir / "filtered_feature_bc_matrix.h5"
+    if not h5.exists():
+        fail(f"missing {h5}")
+    counts, ftype = read_10x_h5(h5)
+    features = [expression_group(counts, ftype)]
+
+    clusters = read_10x_clusters(bin_dir / "analysis")
+    if clusters is not None:
+        features.append(clusters)
+
+    mpp_um = _calibration(bin_dir, bin_size_um, args.pixel_size)
+
+    return SpatialSample(
+        coords=_coords(bin_dir),
+        mpp=mpp_um * 1e-6,
+        coords_name="bins",
+        spot_size=bin_size_um * 1e-6,
+        features=features,
+        image=None,
+    )

--- a/loopy/spatial_io/xenium.py
+++ b/loopy/spatial_io/xenium.py
@@ -1,0 +1,114 @@
+"""10x Xenium reader. Coordinates in microns, origin at the morphology image top-left."""
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import pandas as pd
+
+from .common import (
+    FeatureGroup,
+    SpatialSample,
+    as_str_index,
+    expression_group,
+    fail,
+    read_10x_clusters,
+    read_10x_h5,
+    read_mex,
+)
+
+DEFAULT_PIXEL_SIZE = 0.2125  # microns/px
+QC_COLUMNS = [
+    "transcript_counts", "control_probe_counts", "control_codeword_counts",
+    "total_counts", "cell_area", "nucleus_area",
+]
+
+
+def _pixel_size(folder: Path, override: float | None) -> float:
+    """Microns per pixel: `override` if given, else `pixel_size` from experiment.xenium, else the default."""
+    if override is not None:
+        return override
+    meta = folder / "experiment.xenium"
+    if meta.exists():
+        data = json.loads(meta.read_text())
+        if "pixel_size" in data:
+            return float(data["pixel_size"])
+    print(f"no pixel_size in metadata; using default {DEFAULT_PIXEL_SIZE} um/px")
+    return DEFAULT_PIXEL_SIZE
+
+
+def _cells(folder: Path) -> pd.DataFrame:
+    """Read the per-cell table (cells.parquet or cells.csv.gz), indexed by `cell_id`."""
+    if (folder / "cells.parquet").exists():
+        df = pd.read_parquet(folder / "cells.parquet")
+    elif (folder / "cells.csv.gz").exists():
+        df = pd.read_csv(folder / "cells.csv.gz")
+    else:
+        fail(f"missing cells.parquet / cells.csv.gz in {folder}")
+    if "cell_id" not in df.columns:
+        fail(f"cells table has no 'cell_id' column; found {list(df.columns)}")
+    df.index = as_str_index(df["cell_id"])
+    return df
+
+
+def _expression(folder: Path) -> FeatureGroup:
+    """Read the gene-expression matrix (cell_feature_matrix/ MEX or .h5) as a feature group."""
+    mex = folder / "cell_feature_matrix"
+    if mex.is_dir():
+        counts, ftype = read_mex(mex)
+    elif (folder / "cell_feature_matrix.h5").exists():
+        counts, ftype = read_10x_h5(folder / "cell_feature_matrix.h5")
+    else:
+        fail(f"missing cell_feature_matrix(/.h5) in {folder}")
+    return expression_group(counts, ftype)
+
+
+def _image(folder: Path) -> Path | None:
+    """Locate the morphology image (from experiment.xenium, else a known filename), or None."""
+    meta = folder / "experiment.xenium"
+    if meta.exists():
+        rel = json.loads(meta.read_text()).get("images", {}).get("morphology_focus_filepath")
+        if rel and (folder / rel).exists():
+            return folder / rel
+    for cand in ("morphology_focus.ome.tif", "morphology_mip.ome.tif"):
+        if (folder / cand).exists():
+            return folder / cand
+    return None
+
+
+def read(args: Namespace) -> SpatialSample:
+    """Read a 10x Xenium output directory into a `SpatialSample`.
+
+    Coordinates are the cell centroids (microns) converted to image pixels via the
+    pixel size; feature groups are gene expression, 10x clusters (if present) and QC
+    metrics; the morphology image is used as the background when available.
+    """
+    folder = args.folder
+    if not folder or not folder.is_dir():
+        fail("xenium format requires --folder pointing at a Xenium output directory")
+
+    pixel_size = _pixel_size(folder, args.pixel_size)
+    cells = _cells(folder)
+    coords = pd.DataFrame(
+        {"x": cells["x_centroid"] / pixel_size, "y": cells["y_centroid"] / pixel_size},
+        index=cells.index,
+    )
+
+    features = [_expression(folder)]
+    clusters = read_10x_clusters(folder / "analysis")
+    if clusters is not None:
+        features.append(clusters)
+    qc_cols = [c for c in QC_COLUMNS if c in cells.columns]
+    if qc_cols:
+        features.append(FeatureGroup("QC metrics", cells[qc_cols].copy(), data_type="quantitative"))
+
+    return SpatialSample(
+        coords=coords,
+        mpp=pixel_size * 1e-6,
+        coords_name="cells",
+        spot_size=10e-6,
+        features=features,
+        image=_image(folder),
+        channels=["DAPI"],
+    )

--- a/nextflow/.gitignore
+++ b/nextflow/.gitignore
@@ -1,0 +1,16 @@
+.venv/
+.nextflow/
+.nextflow.log*
+work/
+results/
+test/data/
+test/xenium/
+test/visium/
+test/visium_hd/
+test/spatialdata/
+test/cosmx/
+test/certs/
+__pycache__/
+*.pyc
+results_bundle/
+results_test/

--- a/nextflow/CLAUDE.md
+++ b/nextflow/CLAUDE.md
@@ -1,0 +1,120 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Purpose
+
+The `nextflow/` module of the Samui repo: a Nextflow workflow that preprocesses
+spatial data into the on-disk format consumed by the
+[Samui browser](https://samuibrowser.com) — a web viewer for large multi-channel
+images and their spatial features. It is the batch/headless counterpart to Samui's
+interactive preprocessing GUI, and it drives the repo's own `loopy` package (the
+readers live in `../loopy/spatial_io/`); it is not a standalone project.
+
+## Layout
+
+One entrypoint, `main.nf`, dispatches on `--format` (a platform, `auto`,
+`spatialdata`, or `files`). The reader code lives in the repo's `loopy` package
+(`../loopy/spatial_io/`) and is uv-installed into each task at runtime alongside the
+rest of loopy (see "Runtime" below) — the workflow itself is only the `.nf` files.
+
+- `main.nf` / `modules/preprocess.nf` — the workflow: one `PREPROCESS_SAMUI` process
+  that stages the input(s) plus the package source (`pyproject.toml`, `README.md`,
+  `loopy/`), installs per-format deps (`EXTRA_DEPS` in `modules/preprocess.nf`, via
+  `uvInstall` in `modules/common.nf`), runs the installed `preprocess` CLI, and publishes
+  the sample folder + `index.html`.
+- `../loopy/spatial_io/preprocess.py` — the single CLI (`preprocess` console script,
+  declared in `../pyproject.toml`): parses `--format`, dispatches to a reader, calls the builder.
+- `../loopy/spatial_io/` — the readers. `common.py` holds the `SpatialSample`/`FeatureGroup`
+  intermediate and the **shared** decoders (MEX, 10x `.h5`, `.h5ad`/`anndata_to_sample`,
+  10x clustering, control-feature filtering); `build.py` drives loopy's `Sample`
+  (`add_coords`/`add_chunked_feature`/`add_image`/`write`) — it does not re-implement the
+  coordinate join or feature compression, and only preflight-checks id overlap
+  (`_check_overlap`) since loopy's `join_idx` already left-joins. `__init__.py` has the
+  registry + `detect_format` (auto). One module per format: `xenium`, `visium`,
+  `visium_hd`, `cosmx`, `spatialdata`, `files`. **Add a platform by adding one module
+  that returns a `SpatialSample`** — reuse `common.py`, don't re-implement matrix/cluster reading.
+- `modules/site.nf` — always bundles the viewer: `BUILD_SAMUI` downloads a Samui release
+  (`--samui_version`) and builds its static site in a node container (pnpm; runs as the
+  host uid so pnpm installs to a per-task prefix); `ASSEMBLE_SITE` publishes the viewer
+  at the outdir root with the data folder beside it and injects a bootstrap into the
+  viewer's own `index.html` that points it (via `history.replaceState`, not a redirect,
+  so refresh works) at the sibling sample. Site + data share one origin (no
+  cross-origin/CORS/PNA/whitelist).
+- `test/` — `make_synthetic_data.py` (tiny `files`-mode dataset), `serve_https.py`
+  (local HTTPS+CORS+PNA+range server), `certs/`. Real platform datasets are downloaded
+  into gitignored `test/<platform>/` dirs for end-to-end testing.
+- `docs/formats.md` — per-platform reader reference + real-data deviations.
+  `docs/input-spec.md` — the common model + `files` mode.
+  `context/data-layouts.md` — the observed directory trees + file headers per format.
+
+## Commands
+
+```bash
+python test/make_synthetic_data.py --outdir test/data                 # tiny files-mode dataset
+nextflow run main.nf --format auto   --folder <platform_outs>     --sample_name X --outdir results
+nextflow run main.nf --format files  --cells c.csv --matrix m.csv --sample_name X --outdir results
+python test/serve_https.py --root results --port 8443                 # serve for browser viewing
+```
+
+There is no separate unit-test suite; validation is end-to-end: run the workflow on a
+dataset, then load the published folder in Samui. A reader can be validated without
+Docker by installing the package (`uv pip install --no-deps .` from the repo root, plus
+the deps in `uvInstall`) and importing `loopy.spatial_io.<fmt>`, then checking the
+returned `SpatialSample`.
+
+## Runtime: no Dockerfile
+
+The process runs in the prebuilt `ghcr.io/astral-sh/uv` image (`--uv_image`) and
+installs deps at runtime with `uv` into a per-task `.venv` (see `uvInstall` in
+`modules/common.nf`). The `loopy` package — readers + `preprocess` CLI included — is
+installed `--no-deps` from **this repo checkout**: `main.nf` stages `pyproject.toml`,
+`README.md`, and `loopy/` into the task, `preprocess.nf` assembles them into `samui_src/`,
+and `uvInstall` runs `uv pip install --no-deps ./samui_src`. So runtime uses the current
+working tree (no push needed), and the GUI/`PyQt5` deps are skipped. The host uv cache
+(`--uv_cache`, mounted at `/uv-cache`) makes repeat runs fast. Use the **full** `bookworm`
+image, not `slim` — rasterio's bundled GDAL needs `libexpat.so.1`, which slim lacks.
+
+## Key facts that constrain the implementation
+
+- **loopy needs Pydantic v1.** loopy uses v1 idioms (`.json(exclude=...)`, `@validator`).
+  The runtime install pins `pydantic<2` and installs the package `--no-deps` (which skips
+  the unused PyQt5 GUI dependency), supplying loopy's runtime deps explicitly in `uvInstall`.
+  This pin is why `uv_image` is Python **3.11**, not 3.12: under `pydantic<2`, uv can only
+  resolve a modern `spatialdata` (0.7.x) on 3.11; on 3.12 it backtracks to `spatialdata`
+  0.3.0, whose pinned `numba`/`llvmlite` don't build on 3.12. Verified in-container.
+- **`Sample` is lazy.** `add_coords` / `add_chunked_feature` / `add_image` /
+  `set_default_feature` queue work; nothing is written until `.write()`.
+- **Coords need a unique string index** with `x`/`y` columns; feature-group ids must
+  match. `build._check_overlap` only *validates* id overlap (errors on none, warns on
+  partial); loopy's `join_idx` does the actual left-join, so don't re-implement it here
+  and don't `reindex` (which injects NaN rows that serialize as bogus categories/values).
+- **Sparse orientation flips between formats**: 10x `.h5`/MEX are feature×observation;
+  AnnData `.h5ad` is observation×feature. The `common.py` readers normalize to obs×feature.
+- **Expression matrices stay sparse end-to-end.** The readers return a pandas
+  sparse-backed frame (`from_spmatrix`, never `.toarray()`), `expression_group` filters
+  columns without densifying, and loopy's `sparse_compress_chunked_features` converts via
+  `df.sparse.to_coo()`. This keeps large panels tractable — Xenium Prime (~9.5k genes ×
+  ~407k cells, 80M nnz) peaks at ~5 GB instead of the ~15–31 GB a dense matrix would need.
+- **Image + coords share one pixel space.** Each reader sets `mpp` (meters/pixel) from
+  the platform's units (microns → `µm·1e-6`; image pixels → pixel size); it's applied to
+  both coords and image so the overlay lines up. `--mpp`/`--pixel-size`/`--spot-size`
+  override. Imaging morphology images still load whole into RAM, so the process asks for 16 GB.
+
+## Viewing constraint (important)
+
+Samui's URL loader **forces `https://`** on the data host and fetches cross-origin, so:
+- A plain `http.server` will not work via `?url=...`. Serve over **HTTPS with CORS**
+  (`test/serve_https.py`), or drag-drop the folder into Samui.
+- Local self-signed certs must be trusted by the browser **manually** — and a
+  click-through on the interstitial only covers top-level navigation, **not** Samui's
+  cross-origin `fetch()`. Add the cert to the OS trust store (keychain) instead. Chrome
+  **Private Network Access** also gates public→localhost; `serve_https.py` sends
+  `Access-Control-Allow-Private-Network: true` and supports range requests. Drag-drop
+  avoids all of this. See README "Local testing over HTTPS".
+
+## Known environment issue
+
+`docker run -i` hangs after container exit on some Docker Desktop builds (seen on
+29.4.1/macOS); since Nextflow always passes `-i`, runs stall with the task stuck
+"RUNNING" while the `nxf-*` container shows `Exited (0)`. Restart/update Docker.

--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -1,0 +1,241 @@
+# Nextflow preprocessing workflow
+
+The `nextflow/` module of the [Samui](https://samuibrowser.com) repo: a Nextflow
+workflow that preprocesses spatial-transcriptomics data into a Samui browser sample
+folder, ready to host and view. It is the batch/headless counterpart to Samui's
+interactive preprocessing GUI.
+
+It drives the repo's own `loopy` package (its readers live in `../loopy/spatial_io/`).
+Every input — whichever platform or format it comes in — is reduced to one common
+model (coordinates + feature groups + an optional image, joined by observation id)
+and written as a self-contained folder (`sample.json` + a tiled cloud-optimized
+GeoTIFF + chunked feature data) that Samui loads over HTTP or by drag-and-drop.
+
+## Requirements
+
+- [Nextflow](https://www.nextflow.io/) >= 23.10
+- Docker
+
+There is **no Dockerfile to build**. The process runs in the prebuilt
+[`ghcr.io/astral-sh/uv`](https://github.com/astral-sh/uv) image and installs its
+dependencies at runtime with `uv` into a per-task virtualenv: the loopy deps
+(pinning `pydantic<2`, which loopy requires) plus the `loopy` package itself — which
+carries the readers and the `preprocess` CLI — installed `--no-deps` from **this repo
+checkout** (staged into the task, so runtime uses the current working tree), plus a
+small set of extra packages chosen per `--format`. Downloads are cached on the host
+(`--uv_cache`, default `~/.cache/samui-preprocess-uv`) and mounted into each task, so
+only the first run pays the install cost. Override the base image with `--uv_image` if
+you need a different Python/arch.
+
+## Run
+
+There is a single entrypoint, `main.nf`. The required `--format` selects the input
+mode and which other parameters apply:
+
+| `--format` | input parameter(s) | what it reads |
+|---|---|---|
+| `xenium` | `--folder` | 10x Xenium output directory |
+| `visium` | `--folder` | 10x Visium (Space Ranger) `outs/` (or its parent) |
+| `visium_hd` | `--folder` | 10x Visium HD `outs/` (coarsest `square_NNNum` bin) |
+| `cosmx` | `--folder` | CosMx SMI flat-file export |
+| `auto` | `--folder` | sniff the folder and pick one of the above |
+| `spatialdata` | `--zarr` | a SpatialData `.zarr.zip` or `.zarr` directory |
+| `files` | `--image` / `--cells` / `--features` / `--matrix` | individual files |
+
+```bash
+# A platform output directory
+nextflow run main.nf --format xenium --folder path/to/Xenium_outs --sample_name brain --outdir results
+
+# Let the workflow detect the platform
+nextflow run main.nf --format auto --folder path/to/outs --sample_name s1 --outdir results
+
+# A SpatialData store
+nextflow run main.nf --format spatialdata --zarr path/to/sample.zarr.zip --sample_name s2 --outdir results
+
+# Individual files (AnnData decomposition)
+nextflow run main.nf --format files \
+    --image path/to/image.tif \
+    --cells path/to/cells.csv \
+    --matrix path/to/expression.csv \
+    --features path/to/genes.csv \
+    --sample_name s3 --outdir results
+```
+
+The sample folder is published to `<outdir>/<sample_name>/`. See
+[`docs/formats.md`](docs/formats.md) for the per-platform layout each reader expects
+(and the deviations found in real data) and [`docs/input-spec.md`](docs/input-spec.md)
+for the common model and the `files` mode in detail.
+
+### Parameters
+
+Each reader derives sensible calibration from the platform's own metadata; these
+override it where needed.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `--format` | _(required)_ | input mode (table above) |
+| `--folder` / `--zarr` / `--image`,`--cells`,`--features`,`--matrix` | _(none)_ | input source for the chosen mode |
+| `--outdir` | `results` | directory the sample folder is published into |
+| `--sample_name` | `sample` | sample folder name; also the `&s=` value in the Samui URL |
+| `--mpp` | _(per reader)_ | meters per pixel (image + coords) |
+| `--pixel_size` | _(per reader)_ | microns per pixel (imaging platforms) |
+| `--spot_size` | _(per reader)_ | marker diameter in meters |
+| `--coords_name` | _(per reader)_ | name of the coordinate set (spots/cells/bins/…) |
+| `--default_feature` | _(none)_ | feature shown automatically on load |
+| `--convert_8bit` | `false` | downcast the image to 8-bit |
+| `--no_image` | `false` | skip the background image |
+| `--samui_version` | `v1.1.0` | Samui release tag/branch/commit to build |
+| `--node_image` | `node:22-bookworm` | container used to build the viewer (Samui needs node ≥22) |
+
+### File inputs (`--format files`)
+
+When no platform reader fits, `--format files` takes the pieces of an AnnData object as
+separate files, joined by a shared observation (cell/spot) id:
+
+| Param | Required | Accepted formats | Contents |
+|-------|----------|------------------|----------|
+| `--cells` | **yes** | CSV, Parquet | one row per observation: an id column, `x`/`y` coordinates, and any number of label/metric columns |
+| `--matrix` | **yes** | CSV, Parquet, 10x `.h5`, MEX directory | the expression matrix (counts), observations × features |
+| `--features` | no | CSV, Parquet | one row per feature (gene); used to restrict the matrix to gene-expression features |
+| `--image` | no | TIFF, OME-TIFF | background image drawn under the points |
+
+**`--cells`** — the coordinate/metadata table (AnnData `obs`).
+- *Id column* (optional): the first column named (case-insensitive) `id`, `cell_id`,
+  `barcode`, `cell`, `obs`, or `observation_id` becomes the observation id. If none is
+  present, the row number is used as the id, so the matrix must then align by position.
+- *Coordinates* (required): `x` and `y` columns, in image pixels. Aliases are accepted —
+  `x`/`x_centroid`/`center_x`/`px_x`/`pxl_col_in_fullres` and the `y` equivalents.
+- *Everything else* becomes overlays: text columns form a categorical **Annotations**
+  group, numeric columns a quantitative **Cell metrics** group.
+
+**`--matrix`** — the expression matrix (AnnData `X`); values are counts.
+- CSV/Parquet: the first column holds the ids and the rest are feature columns. The
+  orientation (observations as rows or columns) is detected by matching against the
+  `--cells` ids, so a transposed matrix is fine.
+- A 10x `.h5` file or a MEX directory (`matrix.mtx[.gz]` + `features`/`genes` + `barcodes`)
+  is read directly.
+- Control/background features are dropped by name prefix (`NegPrb*`, `NegControl*`,
+  `SystemControl*`, `Blank-*`/`BLANK_*`).
+
+**`--features`** — per-feature metadata (AnnData `var`), optional. The first column is the
+feature id. If any column name contains `type` (e.g. 10x `feature_types`), only features
+typed `Gene Expression` are kept.
+
+**Calibration.** Coordinates are treated as image pixels unless you pass `--mpp`
+(meters/pixel); `--spot_size` (marker diameter in meters) defaults to `1e-5`, and the
+coordinate set is named `cells`.
+
+A minimal `cells.csv`:
+
+```csv
+id,x,y,cell_type,area
+cell_1,120.5,88.0,Tumor,42.1
+cell_2,131.2,90.4,Stroma,37.8
+```
+
+and a matching `expression.csv` (ids in the first column, features as columns):
+
+```csv
+,GENE1,GENE2,GENE3
+cell_1,3,0,5
+cell_2,0,2,1
+```
+
+`test/make_synthetic_data.py` writes a tiny working `files`-mode dataset (`cells.csv`,
+`matrix.csv`, `image.tif`) you can run end-to-end.
+
+## Output (the published sample folder)
+
+`<outdir>/<sample_name>/` contains everything Samui needs: `sample.json` (the
+manifest), `<coords_name>.csv`, one `<group>.bin` + `<group>.json` per feature group
+(gene expression, clusters/annotations, QC metrics — whichever the platform has), and,
+if an image was added, a tiled pyramidal cloud-optimized GeoTIFF.
+
+## Hosting and viewing
+
+### Bundled single-origin site
+
+The workflow downloads a Samui release (`--samui_version`), builds its static site,
+and publishes it **at the output root** alongside the data:
+
+```bash
+nextflow run main.nf --format auto --folder path/to/outs \
+    --sample_name s1 --outdir results
+```
+
+```
+results/
+├── index.html        # the Samui viewer; auto-loads the co-hosted sample in place
+├── _app/ …           # the viewer's assets (built from the release)
+└── <sample_name>/     # the data
+```
+
+Serve `results/` and open `index.html`: it points the viewer at the sibling
+`<sample_name>/` folder via `history.replaceState` (no redirect), so the data loads on
+the same URL and a browser refresh reloads the same view. The viewer and the data are
+on **one origin**, so there
+are no cross-origin fetches — which sidesteps CORS, Chrome's Private Network Access,
+and the data-host whitelist on the public `samuibrowser.com`. (Self-signed-cert local
+hosting still needs a one-time cert trust for the top-level page, but same-origin
+fetches then just work.) Build requires node ≥22 (`--node_image`); the build runs once
+per `--samui_version` and is cached on `-resume`.
+
+### View the sample folder in a hosted Samui
+
+The `<sample_name>` data folder also works with a hosted Samui without the bundled
+viewer:
+
+1. **Open by URL.** Serve the *parent* of the sample folder over HTTPS+CORS and open
+   `https://samuibrowser.com/from?url=<HOST>&s=<sample_name>`, where `<HOST>` is the
+   host/path **without** a scheme (e.g. `data.example.com/spatial`).
+
+2. **Drag-and-drop** the `<sample_name>` folder onto https://samuibrowser.com — no
+   server needed; all processing is local to the browser.
+
+> Samui forces `https://` on the data host and fetches cross-origin, so the data must
+> be served over HTTPS with CORS. The bundled site avoids this by serving the viewer
+> and data from one origin.
+
+### Local testing over HTTPS
+
+Because Samui forces HTTPS, a plain `python -m http.server` will not work via the
+URL loader. Use the included helper, which serves over HTTPS with CORS:
+
+```bash
+# one-time self-signed cert (already generated under test/certs/ in this repo)
+openssl req -x509 -newkey rsa:2048 -nodes -keyout test/certs/key.pem \
+    -out test/certs/cert.pem -days 365 -subj "/CN=localhost" \
+    -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+
+python test/serve_https.py --root results --port 8443
+```
+
+Then make Chrome **genuinely trust** the self-signed cert (this step is manual —
+self-signed certs can't be accepted programmatically). Clicking **Advanced → Proceed**
+on the interstitial only overrides the cert for *top-level* navigation; Samui fetches
+the data *cross-origin*, and Chrome does **not** apply that override to cross-origin
+`fetch()` — those still fail with `net::ERR_CERT_*` ("Failed to fetch"). Trust it properly:
+
+```bash
+# macOS: add the repo cert to the system keychain as a trusted root, then fully restart Chrome
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \
+    test/certs/cert.pem
+```
+
+Even with a trusted cert, Chrome's **Private Network Access** policy gates requests
+from a public origin (`samuibrowser.com`) to a local one (`localhost`); `serve_https.py`
+answers the PNA preflight with `Access-Control-Allow-Private-Network: true` and serves
+HTTP **range** requests (which the COG image reader needs). Enforcement can still be
+finicky per browser/version. The most reliable local check that avoids HTTPS, CORS and
+PNA entirely is **drag-and-drop**: open https://samuibrowser.com and drag the
+`<outdir>/<sample_name>` folder onto it.
+
+## Known issue: `docker run -i` hang on Docker Desktop
+
+On some Docker Desktop builds (observed with 29.4.1 on macOS), `docker run -i`
+does not return after the container exits — the work completes but the client
+hangs, so Nextflow never sees the task finish. Nextflow always passes `-i`.
+If `nextflow run` stalls with the task stuck "RUNNING" while
+`docker ps -a` shows the `nxf-*` container `Exited (0)`, this is the cause.
+Workarounds: restart Docker Desktop, or update Docker. (For CI/cloud executors
+this does not occur.)

--- a/nextflow/context/data-layouts.md
+++ b/nextflow/context/data-layouts.md
@@ -1,0 +1,82 @@
+# Observed input layouts
+
+Concrete record of the input file/folder structure each `loopy/spatial_io/<format>.py`
+reader consumes, captured from the real example datasets used to validate the
+workflow. The datasets themselves are gitignored (too large) under `test/<format>/`;
+this is the durable record of what they contained.
+
+For what each reader *does* with these (calibration, feature grouping, spec
+deviations), see [`../docs/formats.md`](../docs/formats.md). Columns/headers below are
+the literal ones observed in the example data — treat headers as the source of truth,
+not fixed positions (vendor column names drift across versions).
+
+---
+
+## xenium (`--folder`)
+Example: Xenium V1 FF Mouse Brain Coronal Subset (`*_outs`).
+```
+<region>/
+├── experiment.xenium            # JSON metadata (pixel_size, images{...})
+├── cells.parquet | cells.csv.gz # per-cell summary (coordinates)
+├── cell_feature_matrix/         # MEX: barcodes.tsv.gz, features.tsv.gz, matrix.mtx.gz
+├── cell_feature_matrix.h5       # same matrix, 10x HDF5
+├── analysis/clustering/<gene_expression_graphclust | gene_expression_kmeans_N_clusters>/clusters.csv
+├── morphology_focus.ome.tif     # 2D background (also morphology.ome.tif z-stack, morphology_mip.ome.tif)
+├── cell_boundaries.* / nucleus_boundaries.* / transcripts.* / gene_panel.json   # unused
+```
+- `cells.parquet` cols: `cell_id, x_centroid, y_centroid, transcript_counts, control_probe_counts, control_codeword_counts, total_counts, cell_area, nucleus_area`.
+- `features.tsv.gz`: 3 cols (Ensembl id, gene name, feature type). Types seen: `Gene Expression` 248, `Blank Codeword` 225, `Negative Control Codeword` 41, `Negative Control Probe` 27 (only Gene Expression kept).
+- `clusters.csv` cols: `Barcode, Cluster`. **Join key:** `cell_id` == matrix barcode == clusters `Barcode`.
+
+## visium (`--folder`)
+Example: Targeted Visium Human Glioblastoma (Pan-Cancer), Space Ranger 1.2.
+```
+<run>/outs/
+├── filtered_feature_bc_matrix.h5      (or filtered_feature_bc_matrix/ MEX)
+├── spatial/
+│   ├── tissue_positions_list.csv      # SR1.x: HEADERLESS (SR>=1.3 tissue_positions.csv w/ header; SR2.0+ .parquet)
+│   ├── scalefactors_json.json
+│   └── *_image.png / *.jpg            # previews (no full-res TIFF in minimal set)
+└── analysis/clustering/<graphclust | kmeans_N_clusters>/clusters.csv
+```
+- `tissue_positions_list.csv` columns (no header row): `barcode, in_tissue, array_row, array_col, pxl_row_in_fullres, pxl_col_in_fullres`. Example line: `ACGCCTGACACGCGCT-1,0,0,0,1440,2365`. Keep `in_tissue==1`; x=`pxl_col_in_fullres`, y=`pxl_row_in_fullres`.
+- `scalefactors_json.json` keys: `spot_diameter_fullres, tissue_hires_scalef, fiducial_diameter_fullres, tissue_lowres_scalef`. **Join key:** spot `barcode`.
+
+## visium_hd (`--folder`)
+Example: Visium HD Tiny 3' Mouse Brain, Space Ranger 4.0.1.
+```
+<run>/outs/
+├── binned_outputs/square_{002,008,016}um/
+│   ├── filtered_feature_bc_matrix.h5
+│   ├── spatial/{tissue_positions.parquet, scalefactors_json.json, ...}
+│   └── analysis/clustering/.../clusters.csv
+└── segmented_outputs/            # per-cell (filtered_feature_cell_matrix.h5, cell_segmentations.geojson) — NOT read
+```
+- Reader uses the coarsest bin (prefers `square_016um`).
+- `tissue_positions.parquet` cols (parquet): `barcode, in_tissue, array_row, array_col, pxl_row_in_fullres, pxl_col_in_fullres`.
+- `scalefactors_json.json` keys: `spot_diameter_fullres, bin_size_um, microns_per_pixel, tissue_lowres_scalef, fiducial_diameter_fullres, tissue_hires_scalef, regist_target_img_scalef` (reader uses `microns_per_pixel`). **Join key:** bin `barcode`.
+
+## cosmx (`--folder`)
+Example: CosMx SMI NSCLC Lung9_Rep1 (legacy 2021 flat-file export; prefixed filenames).
+```
+<slide>/
+├── <slide>_exprMat_file.csv       # row per cell; cols: fov, cell_ID, <genes...>, NegPrb*
+├── <slide>_metadata_file.csv      # per-cell coords + morphology
+├── <slide>_fov_positions_file.csv # FOV offsets (unused; global px used directly)
+```
+- exprMat: 982 cols = `fov, cell_ID` + 960 genes + 20 `NegPrb*` (NegPrb/SystemControl dropped). No `polygons.csv` in this legacy export (boundaries are `CellLabels/*.tif`, not shipped here).
+- metadata cols: `fov, cell_ID, Area, AspectRatio, CenterX_local_px, CenterY_local_px, CenterX_global_px, CenterY_global_px, Width, Height, Mean./Max.{MembraneStain,PanCK,CD45,CD3,DAPI}`. x=`CenterX_global_px`, y=`CenterY_global_px` (pixels). **Join key:** composite `f"{fov}_{cell_ID}"`, `cell_ID==0` (background) dropped.
+
+## spatialdata (`--zarr`)
+Example: scverse sandbox MERFISH + MIBI-TOF (`.zarr.zip` → store dir `data.zarr/`, Zarr **v3**).
+```
+data.zarr/
+├── images/   ├── labels/   ├── points/   ├── shapes/   ├── tables/   (which are present varies)
+├── zarr.json (+ zmetadata)
+```
+- merfish: `images=[rasterized] shapes=[anatomical, cells] points=[single_molecule] tables=[table]`; table `(2389, 268)`, **no `obsm['spatial']`** → coords from `shapes['cells']` centroids (joined on the table's instance key).
+- mibitof: `images=[3 points] shapes=[] tables=[table]`; table `(3309, 36)`, `obsm=['X_umap','spatial','X_scanorama']` → coords from `obsm['spatial']`. **Join key:** the table's region/instance key.
+
+## files (`--image`/`--cells`/`--features`/`--matrix`)
+No fixed layout — the AnnData decomposition as separate files. See
+[`../docs/input-spec.md`](../docs/input-spec.md).

--- a/nextflow/docs/formats.md
+++ b/nextflow/docs/formats.md
@@ -49,6 +49,7 @@ concrete directory trees and file headers observed in those datasets are recorde
 - Reads a `.zarr.zip` (extracted to a temp dir) or `.zarr` directory via the `spatialdata` package. Takes the AnnData table; **coords** from the table's `obsm['spatial']` if present, else the matching `shapes` GeoDataFrame `.geometry.centroid` joined on the table's instance key. **Expression** from `X`; categorical `obs` → **Annotations**. `mpp=1e-6` default. Image not exported (future extension).
 - **Tested with:** scverse sandbox MERFISH (2,389 cells, coords via shapes-centroid) and MIBI-TOF (3,309 cells, coords via `obsm['spatial']`).
 - **Deviation found:** the sandbox stores are **Zarr v3** (`zarr.json`) and unzip to a store literally named `data.zarr/`. The MERFISH table has **no** `obsm['spatial']` (coords come from shapes); MIBI-TOF has it.
+- **Deviation found:** stores written by older spatialdata can carry `obs`/`var` names with characters `spatialdata` >=0.7 now rejects at read (e.g. `µm`, `^2`, `a/b`), raising `ValidationError` inside `read_zarr`. The reader catches this and falls back to reading non-table elements via `selection` plus each table directly through `anndata`, then `spatialdata.sanitize_table` (invalid chars → `_`, collisions de-duplicated) — so the sanitized names become the feature/annotation labels.
 
 ## files (`files`, `--image`/`--cells`/`--features`/`--matrix`)
 The platform-agnostic AnnData decomposition expressed as separate files — see

--- a/nextflow/docs/formats.md
+++ b/nextflow/docs/formats.md
@@ -1,0 +1,55 @@
+# Supported formats
+
+Every reader lives in `loopy/spatial_io/<format>.py` and returns one `SpatialSample`
+(coordinates keyed by a unique string observation id + named feature groups +
+optional image), which `loopy/spatial_io/build.py` turns into a loopy Sample. The
+shared matrix decoders, control-feature filtering and 10x clustering reader live in
+`loopy/spatial_io/common.py`; each reader only locates files and normalizes ids/units.
+
+Select a reader with `--format`. Folder-based platforms take `--folder`; `spatialdata`
+takes `--zarr`; `files` takes `--image`/`--cells`/`--features`/`--matrix`. `auto`
+sniffs `--folder` (handling a Space Ranger `outs/` wrapper) and dispatches.
+
+Each row notes the calibration the reader derives, the feature groups it emits, and
+anything in the **real test dataset** that deviated from the published format spec.
+"Tested with" names the dataset the reader was validated against end-to-end. The
+concrete directory trees and file headers observed in those datasets are recorded in
+[`../context/data-layouts.md`](../context/data-layouts.md).
+
+---
+
+## Xenium (`xenium`, `--folder`)
+- **Observation:** cell. **Coords:** `cells.parquet`/`cells.csv.gz` `x/y_centroid` (microns) ÷ `pixel_size` → pixels; `mpp = pixel_size·1e-6` (from `experiment.xenium`, default 0.2125 µm). **spot_size** 10 µm.
+- **Expression:** `cell_feature_matrix/` (MEX) or `cell_feature_matrix.h5`, filtered to `Gene Expression`.
+- **Annotations:** `analysis/clustering/*/clusters.csv` → categorical **Clusters**. **QC metrics** from the `cells` table.
+- **Image:** `morphology_focus.ome.tif` (or `morphology_mip`), channel `DAPI`, with graceful fallback if the JPEG-2000 OME-TIFF can't be decoded.
+- **Tested with:** Xenium V1 FF Mouse Brain Coronal Subset (36,602 cells, 248 genes, image).
+- **Note:** v2.0+ multi-file `morphology_focus/` directories aren't handled (degrades to image-less).
+
+## Visium (`visium`, `--folder`)
+- **Observation:** 55 µm spot. **Coords:** `spatial/tissue_positions*.csv`/`.parquet`, `x=pxl_col_in_fullres`, `y=pxl_row_in_fullres`, filtered to `in_tissue==1`. `mpp = (55 / spot_diameter_fullres)·1e-6` from `scalefactors_json.json`. **spot_size** 55 µm.
+- **Expression:** `filtered_feature_bc_matrix.h5` or `/` (MEX), filtered to `Gene Expression`. **Annotations:** `analysis/clustering/*` → **Clusters**.
+- **Image:** none (public minimal sets ship only PNG previews).
+- **Tested with:** Targeted Visium Human Glioblastoma (Pan-Cancer), SR 1.2 (3,468 in-tissue spots, 1,253 genes).
+- **Deviation found:** SR 1.x ships `tissue_positions_list.csv` (the `_list` suffix), **headerless**; the reader detects header presence and the fixed column order. (SR ≥1.3 has a header; SR 2.0+ is parquet.)
+
+## Visium HD (`visium_hd`, `--folder`)
+- **Observation:** square bin. Reader uses the **coarsest** available bin (prefers `square_016um`). **Coords:** `binned_outputs/square_NNNum/spatial/tissue_positions.parquet` (parquet), `in_tissue==1`, x/y from `pxl_col/row_in_fullres`. `mpp` from `scalefactors_json.json` `microns_per_pixel` (fallback `bin_um / spot_diameter_fullres`). **spot_size** = bin size.
+- **Expression:** `square_NNNum/filtered_feature_bc_matrix.h5`. **Annotations:** that bin's `analysis/clustering/*`.
+- **Tested with:** Visium HD Tiny 3' Mouse Brain, SR 4.0.1 (5,262 in-tissue 16 µm bins, 32,245 genes).
+- **Not implemented:** the `segmented_outputs/` per-cell path (needs GeoJSON-centroid parsing and the integer `cell_id` ↔ `cellid_00000000N-1` translation) — noted as a future extension in the module.
+
+## CosMx SMI (`cosmx`, `--folder`)
+- **Observation:** cell. **Coords:** `*_metadata_file.csv` `CenterX/Y_global_px` (pixels); `mpp` default 0.12028 µm/px (override with `--pixel_size`). **spot_size** 10 µm.
+- **Expression:** `*_exprMat_file.csv` (row per cell), join key = composite `f"{fov}_{cell_ID}"`, `cell_ID==0` (background) dropped; `NegPrb*`/`SystemControl*` dropped. **Cell metrics** (Area, intensities, …) as a quantitative group. No native annotation.
+- **Tested with:** NSCLC Lung9_Rep1 legacy SMI flat files (91,972 cells, 960 genes, 20 NegPrb dropped).
+- **Deviations found:** legacy 2021 export — filenames **prefixed**, **no `polygons.csv`** (boundaries are `CellLabels/*.tif` masks, unused), no `SystemControl*` columns present. Column lookups are case/alias tolerant (`fov`/`FOV`, `cell_ID`/`cell_id`).
+
+## SpatialData (`spatialdata`, `--zarr`)
+- Reads a `.zarr.zip` (extracted to a temp dir) or `.zarr` directory via the `spatialdata` package. Takes the AnnData table; **coords** from the table's `obsm['spatial']` if present, else the matching `shapes` GeoDataFrame `.geometry.centroid` joined on the table's instance key. **Expression** from `X`; categorical `obs` → **Annotations**. `mpp=1e-6` default. Image not exported (future extension).
+- **Tested with:** scverse sandbox MERFISH (2,389 cells, coords via shapes-centroid) and MIBI-TOF (3,309 cells, coords via `obsm['spatial']`).
+- **Deviation found:** the sandbox stores are **Zarr v3** (`zarr.json`) and unzip to a store literally named `data.zarr/`. The MERFISH table has **no** `obsm['spatial']` (coords come from shapes); MIBI-TOF has it.
+
+## files (`files`, `--image`/`--cells`/`--features`/`--matrix`)
+The platform-agnostic AnnData decomposition expressed as separate files — see
+[`input-spec.md`](input-spec.md).

--- a/nextflow/docs/input-spec.md
+++ b/nextflow/docs/input-spec.md
@@ -1,0 +1,49 @@
+# Common model and `files` mode
+
+## The common model
+
+Whatever the `--format`, every reader produces the same intermediate (a
+`SpatialSample` in `loopy/spatial_io/common.py`):
+
+- **Coordinates** — one `(x, y)` per observation, in pixels, indexed by a unique
+  string observation id. `mpp` (meters per pixel) calibrates them and the image.
+- **Feature groups** — zero or more named tables keyed by the same id, each either
+  `quantitative` (gene expression, QC metrics) or `categorical` (clusters, cell
+  types). Gene-expression groups are stored sparse.
+- **Image** — an optional background TIFF/OME-TIFF, written as a tiled pyramidal COG.
+
+`build.py` writes this as `sample.json` + `<coords_name>.csv` + a `.bin`/`.json` pair
+per feature group + the COG, and (optionally) an `index.html`. Platform readers
+([`docs/formats.md`](formats.md)) only differ in where the bytes live and what units
+the coordinates are in.
+
+## `files` mode (`--format files`)
+
+For data that isn't in one of the supported platform layouts, supply the pieces
+directly — the AnnData decomposition as separate files:
+
+| Param | Required | Format | Role |
+|-------|----------|--------|------|
+| `--cells` | **yes** | CSV / Parquet | per-observation table (`obs`): the id column + `x`/`y` coordinates + any label/metric columns |
+| `--matrix` | **yes** | CSV / Parquet / 10x `.h5` / MEX dir | expression matrix (`X`), cells × features (orientation auto-detected against the cell ids) |
+| `--features` | no | CSV / Parquet | per-feature metadata (`var`); if it has a feature-type column, it is used to keep only gene-expression features |
+| `--image` | no | TIFF / OME-TIFF | background image |
+
+- **Coordinates:** the `--cells` table must have an id column (`id`/`cell_id`/`barcode`/…)
+  and `x`/`y` columns (aliases like `x_centroid`/`center_x`/`pxl_col_in_fullres` are
+  accepted). Remaining non-numeric columns become a categorical **Annotations** group;
+  remaining numeric columns become a quantitative **Cell metrics** group.
+- **Expression:** control/background features (`NegPrb*`, `SystemControl*`, `Blank-*`)
+  are dropped; observation ids are matched to the cells table.
+- **Calibration:** `--mpp` defaults to `1.0` (coordinates are treated as image pixels);
+  `--spot_size` defaults to `1e-5` m. Override as needed.
+
+```bash
+nextflow run main.nf --format files \
+    --cells cells.csv --matrix expression.csv --image image.tif \
+    --mpp 0.5e-6 --spot_size 1e-5 --default_feature GENE1 \
+    --sample_name s1 --outdir results
+```
+
+`test/make_synthetic_data.py` writes a tiny `files`-mode dataset (a `cells.csv`, a
+`matrix.csv`, and an `image.tif`) for a quick end-to-end check.

--- a/nextflow/main.nf
+++ b/nextflow/main.nf
@@ -1,0 +1,54 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { PREPROCESS_SAMUI } from './modules/preprocess'
+include { BUILD_SAMUI; ASSEMBLE_SITE } from './modules/site'
+
+// Single entrypoint. --format selects the input mode:
+//   named platform (xenium|visium|visium_hd|cosmx) or `auto`
+//                          -> read from --folder
+//   spatialdata            -> read from --zarr (.zarr.zip or .zarr directory)
+//   files                  -> --image / --cells / --features / --matrix
+workflow {
+    log.info "Parameters:\n" + params.collect { k, v -> "  ${k} = ${v}" }.sort().join("\n")
+
+    if (!params.format) {
+        error "Missing required parameter --format (a platform, 'auto', 'spatialdata', or 'files')"
+    }
+
+    // Ensure the mounted uv cache dir exists and is owned by the host user.
+    file(params.uv_cache).mkdirs()
+
+    def staged
+    if (params.format == 'spatialdata') {
+        if (!params.zarr) error "--format spatialdata requires --zarr"
+        staged = [file(params.zarr, checkIfExists: true)]
+    } else if (params.format == 'files') {
+        if (!params.cells || !params.matrix) error "--format files requires --cells and --matrix"
+        staged = [params.image, params.cells, params.features, params.matrix]
+            .findAll { p -> p }
+            .collect { p -> file(p, checkIfExists: true) }
+    } else {
+        if (!params.folder) error "--format ${params.format} requires --folder"
+        staged = [file(params.folder, checkIfExists: true)]
+    }
+
+    // Install the readers + `preprocess` CLI from this repo checkout (the loopy
+    // package), so runtime uses the current source without a push. projectDir is
+    // nextflow/; the package lives at the repo root beside it.
+    def repoRoot = file("${projectDir}/..")
+    def pkgSrc = [
+        file("${repoRoot}/pyproject.toml", checkIfExists: true),
+        file("${repoRoot}/README.md",      checkIfExists: true),
+        file("${repoRoot}/loopy",          checkIfExists: true),
+    ]
+
+    PREPROCESS_SAMUI(channel.value(staged), channel.value(pkgSrc))
+
+    // Build the Samui viewer from a release and co-host it with the data, so the
+    // published output is a single-origin static site (no cross-origin fetches).
+    BUILD_SAMUI(params.samui_version)
+    ASSEMBLE_SITE(PREPROCESS_SAMUI.out.sample, BUILD_SAMUI.out.build)
+    ASSEMBLE_SITE.out.site.collect().view { "Bundled Samui site published to: ${params.outdir} (serve it and open index.html)" }
+}

--- a/nextflow/modules/common.nf
+++ b/nextflow/modules/common.nf
@@ -1,0 +1,23 @@
+// Runtime setup shared by all Samui preprocessing processes.
+//
+// Dependencies are installed at runtime with uv into a venv in the task work dir,
+// against a prebuilt uv image — so there is no Dockerfile to maintain. The loopy
+// package (which now contains the `spatial_io` readers and the `preprocess` CLI) is
+// installed from the current checkout of this repo, staged into the task as
+// `samui_src`, without its deps (--no-deps) to skip the unused PyQt5 GUI dependency;
+// its runtime deps are the explicit `deps` list below.
+//
+// extraDeps lets a data-type-specific process add packages its reader needs
+// (e.g. the Xenium reader needs pyarrow for cells.parquet and imagecodecs so
+// tifffile can decode the JPEG-2000 morphology image).
+
+def uvInstall(String extraDeps = '', String srcDir = 'samui_src') {
+    def deps = 'numpy pandas "pydantic>=1.10,<2" rasterio tifffile scipy anndata rich typing-extensions requests'
+    """
+    export HOME="\$PWD"
+    uv venv .venv
+    uv pip install --python .venv --quiet ${deps} ${extraDeps}
+    uv pip install --python .venv --quiet --no-deps ./${srcDir}
+    . .venv/bin/activate
+    """.stripIndent()
+}

--- a/nextflow/modules/preprocess.nf
+++ b/nextflow/modules/preprocess.nf
@@ -1,0 +1,71 @@
+include { uvInstall } from './common'
+
+// Per-format extra pip dependencies on top of the base loopy set (which already
+// brings numpy/pandas/scipy/anndata/h5py/tifffile/rasterio). Only what a format's
+// reader actually needs is installed. `auto` installs the union of the platforms
+// detect_format can return, since the platform is unknown until the folder is
+// sniffed at runtime. Defined as a function because a bare top-level assignment is
+// not a valid Nextflow script declaration.
+def extraDeps(String fmt) {
+    def deps = [
+        xenium:      'pyarrow imagecodecs',
+        visium:      'imagecodecs',
+        visium_hd:   'pyarrow shapely imagecodecs',
+        cosmx:       '',
+        spatialdata: 'zarr spatialdata',
+        files:       'pyarrow imagecodecs',
+        auto:        'pyarrow imagecodecs shapely',
+    ]
+    return deps.getOrDefault(fmt, '')
+}
+
+process PREPROCESS_SAMUI {
+    tag "${params.sample_name}"
+    // ASSEMBLE_SITE publishes the combined site; this process only stages the sample.
+
+    input:
+    path staged
+    path pkgsrc   // package source (pyproject.toml, README.md, loopy/) from this repo checkout
+
+    output:
+    path "${params.sample_name}", emit: sample
+
+    script:
+    def fmt = params.format
+    def src
+    if (fmt == 'spatialdata') {
+        src = "--zarr ${file(params.zarr).name}"
+    } else if (fmt == 'files') {
+        src = [
+            params.image    ? "--image ${file(params.image).name}"       : '',
+            params.cells    ? "--cells ${file(params.cells).name}"       : '',
+            params.features ? "--features ${file(params.features).name}" : '',
+            params.matrix   ? "--matrix ${file(params.matrix).name}"     : '',
+        ].findAll { arg -> arg }.join(' ')
+    } else {
+        src = "--folder ${file(params.folder).name}"
+    }
+
+    def calib = [
+        params.pixel_size      != null ? "--pixel-size ${params.pixel_size}"             : '',
+        params.mpp             != null ? "--mpp ${params.mpp}"                           : '',
+        params.spot_size       != null ? "--spot-size ${params.spot_size}"              : '',
+        params.coords_name             ? "--coords-name '${params.coords_name}'"         : '',
+        params.default_feature         ? "--default-feature '${params.default_feature}'" : '',
+    ].findAll { arg -> arg }.join(' ')
+    def imgopt = [
+        params.convert_8bit ? '--convert-8bit' : '',
+        params.no_image     ? '--no-image'     : '',
+    ].findAll { arg -> arg }.join(' ')
+    def extra = extraDeps(fmt)
+    """
+    # Assemble the staged package files into a single tree for `uv pip install`.
+    mkdir -p samui_src && cp -RL pyproject.toml README.md loopy samui_src/
+    ${uvInstall(extra)}
+    preprocess \\
+        --format ${fmt} \\
+        --outdir . \\
+        --sample-name '${params.sample_name}' \\
+        ${src} ${calib} ${imgopt}
+    """
+}

--- a/nextflow/modules/site.nf
+++ b/nextflow/modules/site.nf
@@ -1,0 +1,80 @@
+// Optional: bundle the Samui viewer with the data so the published output is a
+// self-contained static site served from one origin (no cross-origin/CORS/whitelist).
+
+// Download a Samui release and build its static site. The build runs as the host
+// uid (Nextflow's docker -u), so pnpm is installed into a writable per-task prefix
+// rather than globally, and HOME/store point inside the work dir.
+process BUILD_SAMUI {
+    tag "${version}"
+    container params.node_image
+
+    input:
+    val version
+
+    output:
+    path "samui_build", emit: build
+
+    script:
+    """
+    export HOME="\$PWD"
+    export PATH="\$PWD/.npm-global/bin:\$PATH"
+    npm config set prefix "\$PWD/.npm-global"
+    npm install -g pnpm@10 >/dev/null 2>&1
+
+    curl -fsSL -o samui.tar.gz "https://github.com/chaichontat/samui/archive/${version}.tar.gz"
+    mkdir -p src && tar xzf samui.tar.gz -C src --strip-components=1
+    cd src
+    pnpm install --no-frozen-lockfile --store-dir "\$PWD/.pnpm-store"
+    # pnpm 10 gates dependency build scripts; the native ones must build for vite.
+    pnpm rebuild esbuild svelte-preprocess unrs-resolver
+    pnpm run build
+    cd ..
+    mv src/build samui_build
+    """
+}
+
+// Combine the built viewer (at the root) with the data folder into one directory,
+// published so <outdir>/ is the servable site root. The viewer's own index.html loads
+// external data from the ?url=&s= query, so we inject a small bootstrap that points it
+// at the co-hosted sample in place (history.replaceState, not a redirect) — the data
+// stays on one URL, so a browser refresh reloads the same view.
+process ASSEMBLE_SITE {
+    tag "${params.sample_name}"
+    container params.uv_image
+    // Publish the site CONTENTS at the outdir root (strip the staging `site/` prefix)
+    // so the viewer's absolute /_app paths resolve against the host root.
+    publishDir "${params.outdir}", mode: 'copy', saveAs: { fname -> fname.replaceFirst(/^site\//, '') }
+
+    input:
+    path sample
+    path build
+
+    output:
+    path "site/**", emit: site
+
+    script:
+    """
+    mkdir site
+    cp -R ${build}/. site/
+    rm -f site/visiumif.html          # drop Samui's bundled demo route
+    cp -R ${sample} site/
+    SAMPLE='${params.sample_name}' python3 - site/index.html <<'PY'
+import json, os, sys
+# Inject before the viewer hydrates: if no ?url= is set, point it at the sibling
+# sample on this same host/dir, then let Samui's normal init read the query.
+boot = (
+    "<script>(function(){"
+    "if(new URLSearchParams(location.search).get('url'))return;"
+    "var p=location.pathname,d=p.slice(0,p.lastIndexOf('/'));"
+    "history.replaceState(null,'',p+'?url='+location.host+d+'&s='+encodeURIComponent("
+    + json.dumps(os.environ["SAMPLE"]) + "));"
+    "})();</script>"
+)
+path = sys.argv[1]
+with open(path) as f:
+    html = f.read()
+with open(path, "w") as f:
+    f.write(html.replace("</head>", boot + "</head>", 1))
+PY
+    """
+}

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -1,0 +1,71 @@
+manifest {
+    name            = 'samui-spatial-preprocess'
+    description     = 'Preprocess spatial data into a Samui browser sample folder'
+    mainScript      = 'main.nf'
+    nextflowVersion = '>=23.10.0'
+}
+
+params {
+    // Input mode. One of: xenium, visium, visium_hd, cosmx (read from --folder);
+    // auto (detect from --folder); spatialdata (read from --zarr); files (read from
+    // --image/--cells/--features/--matrix).
+    format          = null      // required
+
+    // Folder-based platforms + auto
+    folder          = null      // platform output directory
+    // SpatialData
+    zarr            = null      // .zarr.zip or .zarr directory
+    // files mode (AnnData decomposition as separate files)
+    image           = null      // TIFF/OME-TIFF background image
+    cells           = null      // per-cell table: coordinates + labels (obs)
+    features        = null      // per-feature metadata table (var, optional)
+    matrix          = null      // expression matrix, cells x features (X)
+
+    // Output
+    outdir          = 'results'
+    sample_name     = 'sample'
+
+    // Calibration / presentation (each reader sets sensible defaults; these override)
+    mpp             = null      // meters per pixel (image + coords)
+    pixel_size      = null      // microns per pixel (imaging platforms)
+    spot_size       = null      // marker diameter in meters
+    coords_name     = null      // name of the coordinate set
+    default_feature = null      // feature shown by default on load
+
+    // Image handling
+    convert_8bit    = false     // downcast image to 8-bit
+    no_image        = false     // skip the background image
+
+    // Bundle the Samui viewer with the data into a single-origin static site
+    samui_version   = 'v1.1.0'            // Samui release tag/branch/commit to build
+    node_image      = 'node:22-bookworm'  // Samui requires node >= 22
+
+    // Runtime environment.
+    // Python 3.11 (not 3.12): under loopy's pydantic<2 pin, uv can only resolve a
+    // modern `spatialdata` (0.7.x) on 3.11; on 3.12 it backtracks to spatialdata
+    // 0.3.0, whose numba/llvmlite won't build on 3.12. All other formats work on 3.11.
+    uv_image        = 'ghcr.io/astral-sh/uv:python3.11-bookworm'
+    uv_cache        = "${System.getProperty('user.home')}/.cache/samui-preprocess-uv"
+}
+
+process {
+    cpus      = 4
+    memory    = '16 GB'        // imaging-platform morphology images load whole into RAM
+    container = params.uv_image
+
+    withName: BUILD_SAMUI {
+        container = params.node_image
+        cpus      = 2
+        memory    = '8 GB'     // vite/svelte build
+    }
+}
+
+docker {
+    enabled    = true
+    // Mount a persistent uv cache so per-sample runtime installs reuse downloads.
+    runOptions = "-u \$(id -u):\$(id -g) -v ${params.uv_cache}:/uv-cache"
+}
+
+env {
+    UV_CACHE_DIR = '/uv-cache'
+}

--- a/nextflow/test/make_synthetic_data.py
+++ b/nextflow/test/make_synthetic_data.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Generate a tiny synthetic dataset for the `files` input mode: a single-channel
+TIFF image, a cells table (id,x,y + a categorical label) and an expression matrix
+(genes x cells). Coordinates land on bright blobs in the image so a correct overlay
+is visually obvious in the Samui browser.
+
+  nextflow run main.nf --format files \
+      --cells test/data/cells.csv --matrix test/data/matrix.csv --image test/data/image.tif \
+      --sample_name synthetic --outdir results --mpp 0.5e-6 --default_feature gene_0
+"""
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import tifffile
+
+N_CELLS = 200
+N_GENES = 50
+IMG_SIZE = 512  # pixels
+BLOB_SIGMA = 6.0
+SEED = 0
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--outdir", type=Path, default=Path("test/data"))
+    args = p.parse_args()
+    args.outdir.mkdir(parents=True, exist_ok=True)
+
+    rng = np.random.default_rng(SEED)
+    ids = [f"cell_{i}" for i in range(N_CELLS)]
+    gene_ids = [f"gene_{g}" for g in range(N_GENES)]
+    coords_px = rng.integers(20, IMG_SIZE - 20, size=(N_CELLS, 2))
+
+    img = rng.normal(300, 30, size=(IMG_SIZE, IMG_SIZE)).clip(0)
+    yy, xx = np.mgrid[0:IMG_SIZE, 0:IMG_SIZE]
+    for x, y in coords_px:
+        img += 4000 * np.exp(-(((xx - x) ** 2 + (yy - y) ** 2) / (2 * BLOB_SIGMA**2)))
+    tifffile.imwrite(args.outdir / "image.tif", img.astype(np.uint16))
+
+    pd.DataFrame(
+        {
+            "id": ids,
+            "x": coords_px[:, 0],
+            "y": coords_px[:, 1],
+            "celltype": rng.choice(["A", "B", "C"], N_CELLS),
+        }
+    ).to_csv(args.outdir / "cells.csv", index=False)
+
+    # Genes (rows) x cells (cols) — the common gene-matrix orientation; the reader
+    # auto-orients against the cell ids. A couple of genes are made spatially
+    # structured so the overlay shows a gradient.
+    counts = rng.poisson(lam=3.0, size=(N_GENES, N_CELLS)).astype(float)
+    counts[0] += (coords_px[:, 0] / IMG_SIZE) * 30.0  # gene_0: left-to-right gradient
+    counts[1] += (coords_px[:, 1] / IMG_SIZE) * 30.0  # gene_1: top-to-bottom
+    pd.DataFrame(counts, index=gene_ids, columns=ids).to_csv(args.outdir / "matrix.csv")
+
+    print(f"Wrote image.tif ({IMG_SIZE}x{IMG_SIZE}), cells.csv ({N_CELLS} cells), "
+          f"matrix.csv ({N_GENES} genes x {N_CELLS} cells) to {args.outdir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/nextflow/test/serve_https.py
+++ b/nextflow/test/serve_https.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Serve a directory over HTTPS with CORS headers for local Samui testing.
+
+The Samui browser at https://samuibrowser.com forces https:// on the data host
+and runs cross-origin, so a sample folder must be served over HTTPS with a CORS
+policy that allows the Samui origin. This is a test helper only.
+
+Usage:
+  python test/serve_https.py --root /path/to/outdir --port 8443 \
+      --cert test/certs/cert.pem --key test/certs/key.pem
+
+Then in Chrome accept the self-signed cert once by visiting
+https://localhost:8443/ and proceeding past the warning, and open:
+  https://samuibrowser.com/from?url=localhost:8443&s=<SAMPLE_NAME>
+"""
+import argparse
+import os
+import re
+import ssl
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+
+
+class CORSHandler(SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "*")
+        # Samui is served from a public origin (samuibrowser.com) but this server is
+        # on localhost (a private address). Chrome's Private Network Access policy
+        # blocks public->private requests unless the preflight grants it explicitly.
+        self.send_header("Access-Control-Allow-Private-Network", "true")
+        # Let the browser read length/range headers so the COG tile reader works.
+        self.send_header("Access-Control-Expose-Headers", "Content-Length, Content-Range, Accept-Ranges")
+        super().end_headers()
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self.end_headers()
+
+    def do_GET(self):
+        # Serve byte ranges (206) when asked. The stdlib handler ignores Range and
+        # returns the whole file with 200, which makes geotiff.js re-download the
+        # entire COG per tile request and stall on large images.
+        m = re.match(r"bytes=(\d+)-(\d*)\s*$", self.headers.get("Range", ""))
+        path = self.translate_path(self.path)
+        if not m or not os.path.isfile(path):
+            return super().do_GET()
+
+        size = os.path.getsize(path)
+        start = int(m.group(1))
+        end = int(m.group(2)) if m.group(2) else size - 1
+        end = min(end, size - 1)
+        if start > end:
+            self.send_response(416)
+            self.send_header("Content-Range", f"bytes */{size}")
+            self.end_headers()
+            return
+
+        self.send_response(206)
+        self.send_header("Content-Type", self.guess_type(path))
+        self.send_header("Content-Range", f"bytes {start}-{end}/{size}")
+        self.send_header("Content-Length", str(end - start + 1))
+        self.send_header("Accept-Ranges", "bytes")
+        self.end_headers()
+        with open(path, "rb") as f:
+            f.seek(start)
+            remaining = end - start + 1
+            while remaining > 0:
+                chunk = f.read(min(65536, remaining))
+                if not chunk:
+                    break
+                self.wfile.write(chunk)
+                remaining -= len(chunk)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--root", required=True)
+    p.add_argument("--port", type=int, default=8443)
+    p.add_argument("--cert", default="test/certs/cert.pem")
+    p.add_argument("--key", default="test/certs/key.pem")
+    args = p.parse_args()
+
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(certfile=args.cert, keyfile=args.key)
+
+    httpd = ThreadingHTTPServer(("127.0.0.1", args.port), partial(CORSHandler, directory=args.root))
+    httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+    print(f"Serving {args.root} at https://localhost:{args.port}/")
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 [project.scripts]
 loopy = "loopy.entrypoint:cli"
 samui = "loopy.entrypoint:cli"
+preprocess = "loopy.spatial_io.preprocess:main"
 
 [project.optional-dependencies]
 geo = ["gdal==3.8.4"]


### PR DESCRIPTION
## Summary

Adds a headless Nextflow workflow that preprocesses spatial data into the on-disk format the Samui browser consumes, and bundles the viewer so the published folder renders on its own. It is the batch/CLI counterpart to Samui's interactive preprocessing GUI, driving the repo's own `loopy` package.

- `nextflow/main.nf` + `modules/` dispatch on `--format` (`auto`, `spatialdata`, `files`, or a platform), install per-format deps at runtime with `uv` (no Dockerfile), run the `preprocess` CLI, and publish the sample folder alongside a built copy of the Samui static site.
- New `loopy/spatial_io/` readers — one module per platform (Xenium, Visium, Visium HD, CosMx, SpatialData, `files`) returning a shared `SpatialSample` intermediate — plus the `preprocess` console script (declared in `pyproject.toml`).
- Expression matrices stay sparse end-to-end so large panels (e.g. Xenium Prime ~9.5k genes × ~407k cells) stay tractable.
- Docs under `nextflow/docs/` and `nextflow/context/` capture the common data model, per-platform reader behavior, and observed real-data deviations.

## SpatialData naming-rule handling

The SpatialData reader falls back gracefully when a store written by older spatialdata carries `obs`/`var` names that spatialdata >=0.7 rejects at read time (e.g. `µm`, `^2`, `a/b`). It catches the `ValidationError`, reads the non-table elements via `selection`, reads each table directly through `anndata`, and runs `spatialdata.sanitize_table` so the sanitized names become the feature/annotation labels.

## Testing

No separate unit suite; validation is end-to-end — run the workflow on a dataset and load the published folder in Samui. The SpatialData reader was exercised against the scverse sandbox MERFISH and MIBI-TOF stores; other readers against downloaded platform datasets. See `nextflow/CLAUDE.md` and `nextflow/README.md` for how to run and view locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)