### PR TITLE
Fix scrolling in sample and feature selectors

### DIFF
--- a/src/lib/components/sampleList.browser.test.ts
+++ b/src/lib/components/sampleList.browser.test.ts
@@ -1,11 +1,14 @@
 import { page, userEvent } from 'vitest/browser';
-import { expect, test } from 'vitest';
+import { afterEach, expect, test } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 
 import '$src/app.css';
 import SampleList from './sampleList.svelte';
 
-test('a long sample list stays within the viewport and scrolls', async () => {
+afterEach(() => page.viewport(414, 896));
+
+test('a long sample list stays within a short viewport and the last sample remains selectable', async () => {
+  await page.viewport(414, 320);
   const samples = Array.from({ length: 40 }, (_, index) => `Sample ${index + 1}`);
   const screen = render(SampleList, {
     props: { items: samples, active: samples[0] }
@@ -19,10 +22,28 @@ test('a long sample list stays within the viewport and scrolls', async () => {
   const element = listbox.query();
   if (!(element instanceof HTMLElement)) throw new Error('Sample listbox not mounted');
   await expect
-    .poll(() => element.getBoundingClientRect().bottom)
-    .toBeLessThanOrEqual(window.innerHeight);
+    .poll(() => {
+      const { top, bottom } = element.getBoundingClientRect();
+      return top >= 0 && bottom <= window.innerHeight;
+    })
+    .toBe(true);
   expect(element.scrollHeight).toBeGreaterThan(element.clientHeight);
   expect(getComputedStyle(element).overflowY).toBe('auto');
+
+  element.scrollTop = element.scrollHeight;
+  const lastOption = page.getByTestId('sample-option-Sample 40');
+  await expect
+    .poll(() => {
+      const option = lastOption.query()?.getBoundingClientRect();
+      const bounds = element.getBoundingClientRect();
+      return option !== undefined && option.top >= bounds.top && option.bottom <= bounds.bottom;
+    })
+    .toBe(true);
+
+  await userEvent.click(lastOption);
+  const trigger = page.getByTestId('sample-select');
+  await expect.element(trigger).toHaveTextContent('Sample 40');
+  await expect.element(trigger).toHaveAttribute('aria-expanded', 'false');
 
   screen.unmount();
 });

--- a/src/lib/components/sampleList.browser.test.ts
+++ b/src/lib/components/sampleList.browser.test.ts
@@ -1,0 +1,28 @@
+import { page, userEvent } from 'vitest/browser';
+import { expect, test } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+
+import '$src/app.css';
+import SampleList from './sampleList.svelte';
+
+test('a long sample list stays within the viewport and scrolls', async () => {
+  const samples = Array.from({ length: 40 }, (_, index) => `Sample ${index + 1}`);
+  const screen = render(SampleList, {
+    props: { items: samples, active: samples[0] }
+  });
+
+  await userEvent.click(page.getByTestId('sample-select'));
+
+  const listbox = page.getByRole('listbox');
+  await expect.element(listbox).toBeVisible();
+
+  const element = listbox.query();
+  if (!(element instanceof HTMLElement)) throw new Error('Sample listbox not mounted');
+  await expect
+    .poll(() => element.getBoundingClientRect().bottom)
+    .toBeLessThanOrEqual(window.innerHeight);
+  expect(element.scrollHeight).toBeGreaterThan(element.clientHeight);
+  expect(getComputedStyle(element).overflowY).toBe('auto');
+
+  screen.unmount();
+});

--- a/src/lib/components/sampleList.svelte
+++ b/src/lib/components/sampleList.svelte
@@ -84,37 +84,33 @@
                   {...contentRest}
                   class={classes(
                     contentClass,
-                    'bg-default z-40 mt-2 w-full rounded-lg shadow shadow-blue-900 backdrop-blur'
+                    'bg-default z-40 mt-2 max-h-96 w-full overflow-y-auto rounded-lg py-1 leading-6 shadow shadow-blue-900 backdrop-blur focus:outline-none sm:leading-5'
                   )}
                   transition:fly={{ y: 10, duration: 100, easing: cubicOut }}
                 >
-                  <Select.Viewport
-                    class="overflow-auto rounded-lg pt-1 pb-1 leading-6 focus:outline-none sm:leading-5"
-                  >
-                    {#each rows as { name } (name)}
-                      <div class="px-1" data-testid={`sample-option-${name}`}>
-                        <Select.Item value={name} label={name}>
-                          {#snippet children({ selected, highlighted })}
-                            <div
-                              class={classes(
-                                // 'relative flex w-full items-center gap-2 rounded-lg py-2 pl-3 pr-4'
-                                'w-full relative flex items-center cursor-pointer select-none rounded-lg py-2 pl-3 pr-9 focus:outline-none',
-                                highlighted ? 'hover-default' : ''
-                              )}
-                            >
-                              <div class={classes(selected ? 'font-semibold' : 'font-normal')}>
-                                {name}
-                              </div>
-
-                              <div class={classes(selected && showArrow ? '' : 'opacity-0')}>
-                                <Check class="size-4 stroke-current stroke-2" />
-                              </div>
+                  {#each rows as { name } (name)}
+                    <div class="px-1" data-testid={`sample-option-${name}`}>
+                      <Select.Item value={name} label={name}>
+                        {#snippet children({ selected, highlighted })}
+                          <div
+                            class={classes(
+                              // 'relative flex w-full items-center gap-2 rounded-lg py-2 pl-3 pr-4'
+                              'w-full relative flex items-center cursor-pointer select-none rounded-lg py-2 pl-3 pr-9 focus:outline-none',
+                              highlighted ? 'hover-default' : ''
+                            )}
+                          >
+                            <div class={classes(selected ? 'font-semibold' : 'font-normal')}>
+                              {name}
                             </div>
-                          {/snippet}
-                        </Select.Item>
-                      </div>
-                    {/each}
-                  </Select.Viewport>
+
+                            <div class={classes(selected && showArrow ? '' : 'opacity-0')}>
+                              <Check class="size-4 stroke-current stroke-2" />
+                            </div>
+                          </div>
+                        {/snippet}
+                      </Select.Item>
+                    </div>
+                  {/each}
                 </div>
               </div>
             {/if}

--- a/src/lib/components/sampleList.svelte
+++ b/src/lib/components/sampleList.svelte
@@ -73,7 +73,7 @@
       </Select.Trigger>
 
       <Select.Portal>
-        <Select.Content forceMount side="bottom" align="start" sideOffset={4}>
+        <Select.Content forceMount side="bottom" align="start" sideOffset={12}>
           {#snippet child({ wrapperProps, props, open })}
             {#if open}
               {@const { class: rawContentClass, ...contentRest } = props}
@@ -84,7 +84,7 @@
                   {...contentRest}
                   class={classes(
                     contentClass,
-                    'bg-default z-40 mt-2 max-h-96 w-full overflow-y-auto rounded-lg py-1 leading-6 shadow shadow-blue-900 backdrop-blur focus:outline-none sm:leading-5'
+                    'bg-default z-40 max-h-[min(24rem,var(--bits-select-content-available-height))] w-full overflow-y-auto rounded-lg py-1 leading-6 shadow shadow-blue-900 backdrop-blur focus:outline-none sm:leading-5'
                   )}
                   transition:fly={{ y: 10, duration: 100, easing: cubicOut }}
                 >

--- a/src/lib/sidebar/searchbox/featureSearchBox.browser.test.ts
+++ b/src/lib/sidebar/searchbox/featureSearchBox.browser.test.ts
@@ -1,0 +1,30 @@
+import { page, userEvent } from 'vitest/browser';
+import { expect, test } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+
+import '$src/app.css';
+import FeatureSearchBox from './featureSearchBox.svelte';
+
+test('a long feature-group list stays within the viewport and scrolls', async () => {
+  const featureGroup = Array.from({ length: 40 }, (_, index) => ({
+    group: `Group ${index + 1}`,
+    features: [`Feature ${index + 1}`]
+  }));
+  const screen = render(FeatureSearchBox, { props: { featureGroup } });
+
+  await userEvent.click(page.getByTestId('feature-search-group'));
+
+  const listbox = page.getByRole('listbox');
+  await expect.element(listbox).toBeVisible();
+
+  const element = listbox.query();
+  if (!(element instanceof HTMLElement)) throw new Error('Feature-group listbox not mounted');
+
+  await expect
+    .poll(() => element.getBoundingClientRect().bottom)
+    .toBeLessThanOrEqual(window.innerHeight);
+  expect(element.scrollHeight).toBeGreaterThan(element.clientHeight);
+  expect(getComputedStyle(element).overflowY).toBe('auto');
+
+  screen.unmount();
+});

--- a/src/lib/sidebar/searchbox/featureSearchBox.browser.test.ts
+++ b/src/lib/sidebar/searchbox/featureSearchBox.browser.test.ts
@@ -1,11 +1,14 @@
 import { page, userEvent } from 'vitest/browser';
-import { expect, test } from 'vitest';
+import { afterEach, expect, test } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 
 import '$src/app.css';
 import FeatureSearchBox from './featureSearchBox.svelte';
 
-test('a long feature-group list stays within the viewport and scrolls', async () => {
+afterEach(() => page.viewport(414, 896));
+
+test('a long feature-group list stays within a short viewport and the last group remains selectable', async () => {
+  await page.viewport(414, 320);
   const featureGroup = Array.from({ length: 40 }, (_, index) => ({
     group: `Group ${index + 1}`,
     features: [`Feature ${index + 1}`]
@@ -21,10 +24,28 @@ test('a long feature-group list stays within the viewport and scrolls', async ()
   if (!(element instanceof HTMLElement)) throw new Error('Feature-group listbox not mounted');
 
   await expect
-    .poll(() => element.getBoundingClientRect().bottom)
-    .toBeLessThanOrEqual(window.innerHeight);
+    .poll(() => {
+      const { top, bottom } = element.getBoundingClientRect();
+      return top >= 0 && bottom <= window.innerHeight;
+    })
+    .toBe(true);
   expect(element.scrollHeight).toBeGreaterThan(element.clientHeight);
   expect(getComputedStyle(element).overflowY).toBe('auto');
+
+  element.scrollTop = element.scrollHeight;
+  const lastOption = page.getByText('Group 40', { exact: true });
+  await expect
+    .poll(() => {
+      const option = lastOption.query()?.getBoundingClientRect();
+      const bounds = element.getBoundingClientRect();
+      return option !== undefined && option.top >= bounds.top && option.bottom <= bounds.bottom;
+    })
+    .toBe(true);
+
+  await userEvent.click(lastOption);
+  const trigger = page.getByTestId('feature-search-group');
+  await expect.element(trigger).toHaveTextContent('Group 40');
+  await expect.element(trigger).toHaveAttribute('aria-expanded', 'false');
 
   screen.unmount();
 });

--- a/src/lib/sidebar/searchbox/featureSearchBox.svelte
+++ b/src/lib/sidebar/searchbox/featureSearchBox.svelte
@@ -57,7 +57,7 @@
         </span>
 
         <Select.Portal>
-          <Select.Content forceMount side="bottom" align="start" sideOffset={4} class="z-50">
+          <Select.Content forceMount side="bottom" align="start" sideOffset={8} class="z-50">
             {#snippet child({ wrapperProps, props, open })}
               {#if open}
                 {@const { class: rawContentClass, ...contentRest } = props}
@@ -68,7 +68,7 @@
                     {...contentRest}
                     class={classes(
                       contentClass,
-                      'mt-1 max-h-96 overflow-y-auto rounded-md border border-neutral-200/30 bg-neutral-800 py-1 shadow-lg shadow-neutral-600/50'
+                      'max-h-[min(24rem,var(--bits-select-content-available-height))] overflow-y-auto rounded-md border border-neutral-200/30 bg-neutral-800 py-1 shadow-lg shadow-neutral-600/50'
                     )}
                   >
                     {#each groups as group}

--- a/src/lib/sidebar/searchbox/featureSearchBox.svelte
+++ b/src/lib/sidebar/searchbox/featureSearchBox.svelte
@@ -68,26 +68,24 @@
                     {...contentRest}
                     class={classes(
                       contentClass,
-                      'mt-1 rounded-md border border-neutral-200/30 bg-neutral-800 shadow-lg shadow-neutral-600/50'
+                      'mt-1 max-h-96 overflow-y-auto rounded-md border border-neutral-200/30 bg-neutral-800 py-1 shadow-lg shadow-neutral-600/50'
                     )}
                   >
-                    <Select.Viewport class="py-1">
-                      {#each groups as group}
-                        <Select.Item value={group} label={group}>
-                          {#snippet children({ selected, highlighted })}
-                            <div
-                              class={classes(
-                                'cursor-pointer rounded-md py-1 px-3 text-left focus:outline-none hover:bg-neutral-700',
-                                selected ? 'font-medium' : '',
-                                highlighted ? 'bg-neutral-700' : 'bg-neutral-800'
-                              )}
-                            >
-                              {group}
-                            </div>
-                          {/snippet}
-                        </Select.Item>
-                      {/each}
-                    </Select.Viewport>
+                    {#each groups as group}
+                      <Select.Item value={group} label={group}>
+                        {#snippet children({ selected, highlighted })}
+                          <div
+                            class={classes(
+                              'cursor-pointer rounded-md py-1 px-3 text-left focus:outline-none hover:bg-neutral-700',
+                              selected ? 'font-medium' : '',
+                              highlighted ? 'bg-neutral-700' : 'bg-neutral-800'
+                            )}
+                          >
+                            {group}
+                          </div>
+                        {/snippet}
+                      </Select.Item>
+                    {/each}
                   </div>
                 </div>
               {/if}


### PR DESCRIPTION
- Keep long sample and feature-group dropdowns within the browser viewport.
- Allow users to scroll through all available options instead of clipping lists below the screen.

Resolves #138.
